### PR TITLE
Fix completion of transition systems

### DIFF
--- a/src/automaton/dpa.rs
+++ b/src/automaton/dpa.rs
@@ -427,7 +427,7 @@ mod tests {
                 (1, 'a', 0, 0),
                 (1, 'b', 1, 1),
             ])
-            .collect()
+            .nondeterministic()
             .into_deterministic()
             .with_initial(0)
             .collect_dpa();

--- a/src/transition_system.rs
+++ b/src/transition_system.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 
 use crate::{math::Map, math::Partition, prelude::*};
 use std::{
+    collections::BTreeSet,
     fmt::{Debug, Display},
     hash::Hash,
 };
@@ -211,6 +212,28 @@ pub trait TransitionSystem: Sized {
                 None
             }
         }))
+    }
+
+    /// Checks whether `self` is complete, meaning every state has a transition for every symbol
+    /// of the alphabet.
+    fn is_complete(&self) -> bool {
+        let universe = self.alphabet().universe().collect::<BTreeSet<_>>();
+
+        for q in self.state_indices() {
+            let syms = self
+                .transitions_from(q)
+                .map(|(_q, a, _c, _p)| a)
+                .collect::<BTreeSet<_>>();
+
+            assert!(
+                syms.is_subset(&universe),
+                "Makes no sense to have more symbols on transitions than in the alphabet"
+            );
+            if !universe.is_subset(&syms) {
+                return false;
+            }
+        }
+        true
     }
 
     /// Returns true if and only if there exists a transition from the given `source` state to the

--- a/src/transition_system/deterministic.rs
+++ b/src/transition_system/deterministic.rs
@@ -399,20 +399,6 @@ pub trait Deterministic: TransitionSystem {
         self.last_edge_color_from(word, self.initial())
     }
 
-    /// Checks whether `self` is complete, meaning every state has a transition for every symbol
-    /// of the alphabet.
-    fn is_complete(&self) -> bool {
-        for q in self.state_indices() {
-            if !self
-                .alphabet()
-                .universe()
-                .all(|sym| self.transition(q, sym).is_some())
-            {
-                return false;
-            }
-        }
-        true
-    }
     /// Runs the given `word` on the transition system, starting in the initial state.
     #[allow(clippy::type_complexity)]
     fn omega_run<W>(

--- a/src/transition_system/operations/subset.rs
+++ b/src/transition_system/operations/subset.rs
@@ -216,7 +216,7 @@ mod tests {
                 (1, 'b', 1),
                 (1, 'a', 0),
             ])
-            .collect()
+            .nondeterministic()
             .with_initial(0);
 
         let dts = nts.subset_construction();


### PR DESCRIPTION
We fix an issue with the completion of already complete transition systems. The documentation of this method now test for exactly this edge case.
In the process, the following further changes were implemented:
- improve the `is_complete` method to use `BTreeSet` instead of iteration
- move the `is_complete` method from `Determinstic` to `TransitionSystem`
- add a `with_alphabet_symbols` method to `TSBuilder` for specifying additional alphabet symbols that do not appear on any transitions

Additionally, we renamed the `collect()` method on `TSBuilder` to `nondeterministic()`.