### PR TITLE
Improve documentation of semantics and automaton types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - os_name: Linux-x86_64
-            os: ubuntu-20.04
-            target: x86_64-unknown-linux-gnu
           - os_name: Windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,8 +6,8 @@ on:
       - '*'
         
 jobs:
-  check:
-    name: Run checks and lints
+  check_build:
+    name: Verify correct building
     strategy:
       matrix:
         platform:
@@ -22,6 +22,16 @@ jobs:
             target: x86_64-apple-darwin
 
     runs-on: ${{ matrix.platform.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Setup Rust toolchain with caching
+        uses: brndnmtthws/rust-action@v1
+      - name: Compile
+        run: cargo build
+
+  checks:
+    name: Run tests, verify documentation and formatting
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ jobs:
 
   checks:
     name: Run tests, verify documentation and formatting
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -5,20 +5,23 @@ pub use acceptance_type::OmegaAcceptanceType;
 
 #[macro_use]
 mod moore;
-pub use moore::{IntoMooreMachine, MooreMachine};
+pub use moore::{IntoMooreMachine, MooreMachine, MooreSemantics};
 
 #[macro_use]
 mod mealy;
-pub use mealy::{IntoMealyMachine, MealyMachine};
+pub use mealy::{IntoMealyMachine, MealyMachine, MealySemantics};
 
 mod dfa;
-pub use dfa::{IntoDFA, DFA};
+pub use dfa::{DFASemantics, IntoDFA, DFA};
 
 mod dpa;
-pub use dpa::{IntoDPA, MinEven, DPA};
+pub use dpa::{
+    IntoDPA, MaxEvenParitySemantics, MaxOddParitySemantics, MinEvenParitySemantics,
+    MinOddParitySemantics, DPA,
+};
 
 mod dba;
-pub use dba::{IntoDBA, DBA};
+pub use dba::{DBASemantics, IntoDBA, DBA};
 
 #[allow(missing_docs)]
 mod omega;
@@ -29,43 +32,8 @@ pub use omega::{
 mod with_initial;
 pub use with_initial::Initialized;
 
-/// This module defines different types of _semantics_ that are used by the
-/// [`Automaton`] struct for determining the output of a finite or infinite
-/// run. This can either be some arbitrary output in the case of a Moore or
-/// Mealy machine, or it would be a boolean indicating whether the input is
-/// accepted or not in case of an acceptor like a DFA.
-///
-/// Generally, we distinguish between an [`Automaton`] of finite and one of
-/// infinite words. The purpose of a semantic is to determine what to do
-/// with the run that is induced by an input on some transition system.
-///
-/// # Finite inputs
-/// For a finite input such as a [`FiniteWord`] we use [`FiniteSemantics`],
-/// which defines an `Output` type and provides the [`FininiteSemantics::finite_semantic`] method.
-/// It takes the [`FiniteRun`] that is the result of running the finite
-/// input in some transition system and turns it into the desired output.
-///
-/// Examples of this semantic are for example the [`MooreSemantics`], which
-/// for a finite word `w` simply produce the color of the state that is
-/// reached when running `w` in the transition system from the initial state.
-/// This is similar to the [`DFASemantics`], which additionaly demand that
-/// the state colors are `bool`.
-/// Further, there is also the [`MealySemantics`], which outputs the last
-/// transition that is taken when reading `w`.
-///
-/// # Infinite inputs
-/// For an infinite input like an [`OmegaWord`], we also need to define an
-/// `Output` type. This is now computed in the [`omega_semantic`] method on
-/// the [`OmegaSemantics`] trait. It does this based on an [`OmegaRun`].
-///
-/// Examples include the [`DBASemantics`], which may be applied to `bool`
-/// edge-colored transition systems. It outputs `true` if any edge labeled
-/// with `true` is visited infinitely often and `false` otherwise.
-/// This can actually be viewed as an instantiation of the [`MinEven`]
-/// semantics that a [`DPA`] uses, which outputs the least priority/color
-/// among those that are labels of edges taken infinitely often.
-pub mod semantics;
-pub use semantics::{FiniteSemantics, OmegaSemantics};
+mod semantics;
+pub use semantics::{FiniteSemantics, OmegaSemantics, Semantics};
 
 /// An automaton consists of a transition system and an acceptance condition.
 /// There are many different types of automata, which can be instantiated from
@@ -146,7 +114,7 @@ where
     /// Transforms the given finite word using the automaton, that means it returns
     /// the output of the acceptance condition on the run of the word.
     pub fn transform<W: FiniteWord<SymbolOf<D>>>(&self, word: W) -> A::Output {
-        self.acceptance.finite_semantic(self.ts.finite_run(word))
+        self.acceptance.evaluate(self.ts.finite_run(word))
     }
 }
 
@@ -160,13 +128,13 @@ where
     where
         A: OmegaSemantics<StateColor<D>, EdgeColor<D>, Output = bool>,
     {
-        self.acceptance.omega_semantic(self.ts.omega_run(word))
+        self.acceptance.evaluate(self.ts.omega_run(word))
     }
 
     /// Transforms the given omega word using the automaton, that means it returns
     /// the output of the acceptance condition on the run of the word.
     pub fn transform<W: OmegaWord<SymbolOf<D>>>(&self, word: W) -> A::Output {
-        self.acceptance.omega_semantic(self.ts.omega_run(word))
+        self.acceptance.evaluate(self.ts.omega_run(word))
     }
 }
 

--- a/src/automaton/dba.rs
+++ b/src/automaton/dba.rs
@@ -1,11 +1,23 @@
 use crate::prelude::*;
 
+/// Defines the [`Semantics`] of a deterministic Büchi automaton (DBA),
+/// which is an acceptor of infinite words. It considers the set of
+/// transitions which is taken infinitely often. If one of those is
+/// colored with `true`, then the automaton accepts, while if all of the
+/// transitions that are taken infinitely often are colored with `false`,
+/// the automaton rejects.
+///
+/// This type will rarely be used on its own, for the automaton that makes
+/// use of it, see [`DBA`].
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
 pub struct DBASemantics;
 
-impl<Q> OmegaSemantics<Q, bool> for DBASemantics {
+impl<Q> Semantics<Q, bool> for DBASemantics {
     type Output = bool;
-    fn omega_semantic<R>(&self, run: R) -> Self::Output
+}
+
+impl<Q> OmegaSemantics<Q, bool> for DBASemantics {
+    fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: OmegaRun<StateColor = Q, EdgeColor = bool>,
     {
@@ -15,8 +27,11 @@ impl<Q> OmegaSemantics<Q, bool> for DBASemantics {
     }
 }
 
-/// A deterministic Büchi automaton (DBA) is a deterministic automaton with Büchi acceptance condition. It accepts a word if it visits an accepting state infinitely often.
-/// It is a special case of a deterministic parity automaton [`super::DPA`] with
+/// A deterministic Büchi automaton (DBA) is a deterministic automaton with Büchi acceptance condition.
+/// It accepts a word if it has a successful infinite run that takes an accepting
+/// transition (i.e. one that is labeled with `true`) infinitely often.
+///
+/// In a certain sense, it is a special case of a deterministic parity automaton [`super::DPA`] with
 /// min even and priorities 0 and 1.
 pub type DBA<A = CharAlphabet> = Automaton<Initialized<DTS<A, Void, bool>>, DBASemantics, true>;
 /// Helper trait for creating a [`DBA`] from a given transition system.

--- a/src/automaton/dfa.rs
+++ b/src/automaton/dfa.rs
@@ -6,6 +6,9 @@ use self::operations::DefaultIfMissing;
 
 use super::StatesWithColor;
 
+/// Defines the [`FiniteSemantics`] that are used by a deterministic finite automaton
+/// [`DFA`]. This leads to a [`FiniteWord`] being accepted if the state that it reaches
+/// is colored with `true`, and the word being rejected otherwise.
 #[derive(Clone, Copy, Default, Hash, Eq, PartialEq)]
 pub struct DFASemantics;
 
@@ -15,9 +18,12 @@ impl std::fmt::Debug for DFASemantics {
     }
 }
 
-impl<C> FiniteSemantics<bool, C> for DFASemantics {
+impl<C> Semantics<bool, C> for DFASemantics {
     type Output = bool;
-    fn finite_semantic<R>(&self, run: R) -> Self::Output
+}
+
+impl<C> FiniteSemantics<bool, C> for DFASemantics {
+    fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: FiniteRun<StateColor = bool, EdgeColor = C>,
     {

--- a/src/automaton/dpa.rs
+++ b/src/automaton/dpa.rs
@@ -8,14 +8,23 @@ use tracing::{info, trace};
 
 use crate::{math::Partition, prelude::*, transition_system::Shrinkable};
 
-/// Represents a parity condition which accepts if and only if the least color that
-/// is seen infinitely often is even.
+/// Represents a min even parity condition which accepts if and only if the least color
+/// that labels a transition that is taken infinitely often, is even. For the automaton
+/// type that makes use of this semantics, see [`DPA`].
+///
+/// Other (equivalent) types of parity conditions, that consider the maximal seen color
+/// or demand that the minimal/maximal recurring color are odd, are defined as
+/// [`MaxEvenParitySemantics`], [`MinOddParitySemantics`] and [`MaxOddParitySemantics`],
+/// respectively.
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MinEven;
+pub struct MinEvenParitySemantics;
 
-impl<Q> OmegaSemantics<Q, usize> for MinEven {
+impl<Q> Semantics<Q, usize> for MinEvenParitySemantics {
     type Output = bool;
-    fn omega_semantic<R>(&self, run: R) -> Self::Output
+}
+
+impl<Q> OmegaSemantics<Q, usize> for MinEvenParitySemantics {
+    fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: OmegaRun<StateColor = Q, EdgeColor = usize>,
     {
@@ -26,24 +35,30 @@ impl<Q> OmegaSemantics<Q, usize> for MinEven {
     }
 }
 
+/// Defines an [`OmegaSemantics`] that outputs `true` if the *maximum* color/priority that
+/// appears infinitely often is *even*. See also [`MinEvenParitySemantics`].
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MaxEven;
+pub struct MaxEvenParitySemantics;
+/// Defines an [`OmegaSemantics`] that outputs `true` if the *minimum* color/priority that
+/// appears infinitely often is *odd*. See also [`MinEvenParitySemantics`].
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MinOdd;
+pub struct MinOddParitySemantics;
+/// Defines an [`OmegaSemantics`] that outputs `true` if the *maximum* color/priority that
+/// appears infinitely often is *odd*. See also [`MinEvenParitySemantics`].
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MaxOdd;
+pub struct MaxOddParitySemantics;
 
 /// A deterministic parity automaton (DPA). It uses a [`DTS`]
 /// as its transition system and a `usize` as its edge color.
 /// The acceptance condition is given by the type `Sem`, which
-/// defaults to [`MinEven`], meaning the automaton accepts
+/// defaults to [`MinEvenParitySemantics`], meaning the automaton accepts
 /// if the least color that appears infinitely often during
 /// a run is even.
-pub type DPA<A = CharAlphabet, Sem = MinEven> =
+pub type DPA<A = CharAlphabet, Sem = MinEvenParitySemantics> =
     Automaton<Initialized<DTS<A, Void, usize>>, Sem, true>;
 /// Helper trait for converting a given transition system into a [`DPA`]
 /// with the given semantics.
-pub type IntoDPA<T, Sem = MinEven> = Automaton<T, Sem, true>;
+pub type IntoDPA<T, Sem = MinEvenParitySemantics> = Automaton<T, Sem, true>;
 
 impl<D> IntoDPA<D>
 where

--- a/src/automaton/semantics.rs
+++ b/src/automaton/semantics.rs
@@ -1,0 +1,23 @@
+use crate::prelude::*;
+
+/// This trait is implemented by acceptance conditions for finite words.
+/// See the module level documentation for details.
+pub trait FiniteSemantics<Q, C> {
+    /// The type of output that this semantic produces.
+    type Output;
+    /// Compute the output for the given finite run.
+    fn finite_semantic<R>(&self, run: R) -> Self::Output
+    where
+        R: FiniteRun<StateColor = Q, EdgeColor = C>;
+}
+
+/// This trait is implemented by acceptance conditions for omega words.
+/// See the module level documentation for more information.
+pub trait OmegaSemantics<Q, C> {
+    /// The type of output that this semantic produces.
+    type Output;
+    /// Compute the output for the given omega run.
+    fn omega_semantic<R>(&self, run: R) -> Self::Output
+    where
+        R: OmegaRun<StateColor = Q, EdgeColor = C>;
+}

--- a/src/automaton/semantics.rs
+++ b/src/automaton/semantics.rs
@@ -1,23 +1,60 @@
 use crate::prelude::*;
-
-/// This trait is implemented by acceptance conditions for finite words.
-/// See the module level documentation for details.
-pub trait FiniteSemantics<Q, C> {
+/// This is the base trait for different types of semantics that are used by the
+/// [`Automaton`] struct for determining the output of a finite or infinite
+/// run. This can either be some arbitrary output in the case of a Moore or
+/// Mealy machine. Or it could be boolean indicating whether the input is
+/// accepted or not in case of an acceptor like a DFA.
+///
+/// Generally, we distinguish between an [`Automaton`] of finite and one of
+/// infinite words. The purpose of a semantic is to determine what to do
+/// with the run that is induced by an input on some transition system.
+/// See [`FiniteSemantics`] and [`OmegaSemantics`] for more details on the
+/// semantics of finite and infinite word acceptors, respectively.
+///
+/// # Finite inputs
+/// For a finite input such as a [`FiniteWord`] we use [`FiniteSemantics`],
+/// which defines an `Output` type and provides the [`FiniteSemantics::evaluate`] method.
+/// It takes the [`FiniteRun`] that is the result of running the finite
+/// input in some transition system and turns it into the desired output.
+///
+/// Examples of this semantic are for example the [`MooreSemantics`], which
+/// for a finite word `w` simply produce the color of the state that is
+/// reached when running `w` in the transition system from the initial state.
+/// This is similar to the [`DFASemantics`], which additionaly demand that
+/// the state colors are `bool`.
+/// Further, there is also the [`MealySemantics`], which outputs the last
+/// transition that is taken when reading `w`.
+///
+/// # Infinite inputs
+/// For an infinite input like an [`OmegaWord`], we also need to define an
+/// `Output` type. This is now computed in the [`OmegaSemantics::evaluate`] method on
+/// the [`OmegaSemantics`] trait. It does this based on an [`OmegaRun`].
+///
+/// Examples include the [`DBASemantics`], which may be applied to `bool`
+/// edge-colored transition systems. It outputs `true` if any edge labeled
+/// with `true` is visited infinitely often and `false` otherwise.
+/// This can actually be viewed as an instantiation of the [`MinEvenParitySemantics`]
+/// semantics that a [`DPA`] uses, which outputs the least priority/color
+/// among those that are labels of edges taken infinitely often.
+pub trait Semantics<Q, C> {
     /// The type of output that this semantic produces.
     type Output;
+}
+
+/// This trait is implemented by acceptance conditions for finite words.
+/// See [`Semantics`] for more details.
+pub trait FiniteSemantics<Q, C>: Semantics<Q, C> {
     /// Compute the output for the given finite run.
-    fn finite_semantic<R>(&self, run: R) -> Self::Output
+    fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: FiniteRun<StateColor = Q, EdgeColor = C>;
 }
 
 /// This trait is implemented by acceptance conditions for omega words.
-/// See the module level documentation for more information.
-pub trait OmegaSemantics<Q, C> {
-    /// The type of output that this semantic produces.
-    type Output;
+/// See [`Semantics`] documentation for more information.
+pub trait OmegaSemantics<Q, C>: Semantics<Q, C> {
     /// Compute the output for the given omega run.
-    fn omega_semantic<R>(&self, run: R) -> Self::Output
+    fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: OmegaRun<StateColor = Q, EdgeColor = C>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,10 @@ pub mod prelude {
         alphabet,
         alphabet::{CharAlphabet, Expression, Symbol},
         automaton::{
-            Automaton, FiniteSemantics, Initialized, IntoDBA, IntoDFA, IntoDPA, IntoMealyMachine,
-            IntoMooreMachine, MealyMachine, MooreMachine, OmegaAcceptanceCondition, OmegaAutomaton,
-            OmegaSemantics, DBA, DFA, DPA,
+            Automaton, DBASemantics, DFASemantics, FiniteSemantics, Initialized, IntoDBA, IntoDFA,
+            IntoDPA, IntoMealyMachine, IntoMooreMachine, MealyMachine, MealySemantics,
+            MinEvenParitySemantics, MooreMachine, MooreSemantics, OmegaAcceptanceCondition,
+            OmegaAutomaton, OmegaSemantics, Semantics, DBA, DFA, DPA,
         },
         congruence::RightCongruence,
         math,


### PR DESCRIPTION
The documentation of semantics types has been greatly improved. Further,
we also renamed some parity semantics to make the names more expressive.