### PR TITLE
Remove `first()`, rework `collect_...` methods, introduce `ForAlphabet`

### DIFF
--- a/benches/ts.rs
+++ b/benches/ts.rs
@@ -32,7 +32,7 @@ fn bench_dts() -> Initialized<DTS<CharAlphabet, usize, usize>> {
             (5, 'c', 19, 3),
             (5, 'd', 18, 5),
         ])
-        .deterministic()
+        .into_dts()
         .with_initial(0)
 }
 

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -172,12 +172,6 @@ impl<D: Sproutable, A: Default, const OMEGA: bool> Sproutable for Automaton<D, A
 where
     D::StateColor: Default,
 {
-    fn new_for_alphabet(alphabet: Self::Alphabet) -> Self {
-        let mut ts = D::new_for_alphabet(alphabet);
-        let initial = ts.add_state::<StateColor<D>>(Default::default());
-        Automaton::from_parts(ts, initial, Default::default())
-    }
-
     fn add_state<X: Into<StateColor<Self>>>(&mut self, color: X) -> Self::StateIndex {
         self.ts.add_state(color)
     }

--- a/src/automaton/dpa.rs
+++ b/src/automaton/dpa.rs
@@ -442,7 +442,7 @@ mod tests {
                 (1, 'a', 0, 0),
                 (1, 'b', 1, 1),
             ])
-            .nondeterministic()
+            .into_nts()
             .into_deterministic()
             .with_initial(0)
             .collect_dpa();
@@ -495,7 +495,7 @@ mod tests {
                     (1, 'a', 1, 1),
                     (1, 'b', 0, 0),
                 ])
-                .deterministic()
+                .into_dts()
                 .with_initial(0)
                 .collect_dpa(),
             NTS::builder()
@@ -508,7 +508,7 @@ mod tests {
                     (2, 'a', 3, 0),
                     (2, 'b', 5, 2),
                 ])
-                .deterministic()
+                .into_dts()
                 .with_initial(0)
                 .collect_dpa(),
         ];
@@ -516,13 +516,13 @@ mod tests {
             NTS::builder()
                 .default_color(())
                 .with_transitions([(0, 'a', 1, 0), (0, 'b', 0, 0)])
-                .deterministic()
+                .into_dts()
                 .with_initial(0)
                 .collect_dpa(),
             NTS::builder()
                 .default_color(())
                 .with_transitions([(0, 'a', 1, 0), (0, 'b', 2, 0)])
-                .deterministic()
+                .into_dts()
                 .with_initial(0)
                 .collect_dpa(),
             NTS::builder()
@@ -533,7 +533,7 @@ mod tests {
                     (1, 'a', 5, 0),
                     (1, 'b', 3, 1),
                 ])
-                .deterministic()
+                .into_dts()
                 .with_initial(0)
                 .collect_dpa(),
         ];
@@ -573,13 +573,13 @@ mod tests {
         let univ = NTS::builder()
             .default_color(())
             .with_transitions([(0, 'a', 0, 0), (0, 'b', 2, 0)])
-            .deterministic()
+            .into_dts()
             .with_initial(0)
             .collect_dpa();
         let aomega = NTS::builder()
             .default_color(())
             .with_transitions([(0, 'a', 0, 0), (0, 'b', 1, 0)])
-            .deterministic()
+            .into_dts()
             .with_initial(0)
             .collect_dpa();
         assert!(univ.includes(&aomega));

--- a/src/automaton/mealy.rs
+++ b/src/automaton/mealy.rs
@@ -118,7 +118,7 @@ mod tests {
                 (2, 'a', 1, 0),
                 (2, 'b', 0, 0),
             ])
-            .deterministic()
+            .into_dts()
             .with_initial(0)
             .into_mealy();
         let mm2: MealyMachine = NTS::builder()
@@ -131,7 +131,7 @@ mod tests {
                 (2, 'a', 1, 0),
                 (2, 'b', 1, 0),
             ])
-            .deterministic()
+            .into_dts()
             .with_initial(0)
             .into_mealy();
         let _mm3: MealyMachine = NTS::builder()
@@ -144,7 +144,7 @@ mod tests {
                 (2, 'a', 1, 0),
                 (2, 'b', 0, 2),
             ])
-            .deterministic()
+            .into_dts()
             .with_initial(0)
             .into_mealy();
 

--- a/src/automaton/with_initial.rs
+++ b/src/automaton/with_initial.rs
@@ -83,7 +83,7 @@ where
         writeln!(
             f,
             "Initialized to state {} with table\n{:?}",
-            self.initial(),
+            self.initial().show(),
             self.ts()
         )
     }
@@ -104,7 +104,7 @@ where
     /// Takes an alphabet and a color and constructs an [`Initialized`] instance with the given alphabet, no
     /// transitions and a single initial state with the given color.
     pub fn with_initial_color(alphabet: A, color: Q) -> Self {
-        let mut ts = DTS::new_for_alphabet(alphabet);
+        let mut ts = DTS::for_alphabet(alphabet);
         let initial = ts.add_state(color);
         Self(ts, initial)
     }
@@ -129,10 +129,6 @@ where
 }
 
 impl<Ts: TransitionSystem + Sproutable> Sproutable for Initialized<Ts> {
-    fn new_for_alphabet(alphabet: Self::Alphabet) -> Self {
-        let ts = Ts::new_for_alphabet(alphabet);
-        Self(ts, <Ts::StateIndex as IndexType>::first())
-    }
     fn add_edge<X, Y, CI>(
         &mut self,
         from: X,

--- a/src/congruence/transitionprofile.rs
+++ b/src/congruence/transitionprofile.rs
@@ -298,7 +298,7 @@ where
                 "{i} -{:?}|{:?}-> {}",
                 rs.sc(),
                 rs.ec(),
-                rs.state()
+                rs.state().show()
             ))
         }
         out
@@ -538,7 +538,7 @@ where
             row.extend(profile.iter().map(|tp| {
                 format!(
                     "{}|{}",
-                    tp.state().blue(),
+                    tp.state().show().blue(),
                     (tp.sc(), tp.ec()).show().purple(),
                 )
             }));

--- a/src/hoa/input.rs
+++ b/src/hoa/input.rs
@@ -45,7 +45,7 @@ pub fn hoa_automaton_to_nts(
 ) -> Initialized<NTS<HoaAlphabet, usize, AcceptanceMask>> {
     let aps = aut.num_aps();
     assert!(aps < MAX_APS);
-    let mut ts = NTS::new_for_alphabet(HoaAlphabet::from_hoa_automaton(&aut));
+    let mut ts = NTS::for_alphabet(HoaAlphabet::from_hoa_automaton(&aut));
     for (id, state) in aut.body().iter().enumerate() {
         assert_eq!(id, state.id() as usize);
         assert_eq!(id, ts.add_state(state.id() as usize));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ pub mod prelude {
             reachable::MinimalRepresentative,
             run::{FiniteRun, OmegaRun},
             Congruence, Deterministic, DeterministicEdgesFrom, Edge, EdgeColor, ExpressionOf,
-            HashTs, IndexType, Indexes, IntoEdge, IsEdge, Path, Sproutable, StateColor, SymbolOf,
-            TSBuilder, TransitionSystem, DTS, NTS,
+            ForAlphabet, HashTs, IndexType, Indexes, IntoEdge, IsEdge, Path, Sproutable,
+            StateColor, SymbolOf, TSBuilder, TransitionSystem, DTS, NTS,
         },
         upw,
         word::{

--- a/src/minimization/partition_refinement.rs
+++ b/src/minimization/partition_refinement.rs
@@ -87,7 +87,7 @@ where
         "Building quotient with partition {{{}}}",
         partition
             .iter()
-            .map(|set| format!("{{{}}}", set.iter().map(|c| c.to_string()).join(", ")))
+            .map(|set| format!("{{{}}}", set.iter().map(|c| c.show()).join(", ")))
             .join(", ")
     );
 
@@ -187,7 +187,7 @@ where
         "Building quotient with partition {{{}}}",
         partition
             .iter()
-            .map(|set| format!("{{{}}}", set.iter().map(|c| c.to_string()).join(", ")))
+            .map(|set| format!("{{{}}}", set.iter().map(|c| c.show()).join(", ")))
             .join(", ")
     );
 

--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
 /// 4. Repeat until all states and symbols have been treated.
 pub fn generate_random_ts(symbols: usize, probability: f64) -> Initialized<DTS> {
     let alphabet = CharAlphabet::alphabetic(symbols);
-    let mut dts = DTS::new_for_alphabet(alphabet.clone());
+    let mut dts = DTS::for_alphabet(alphabet.clone());
 
     let mut current = dts.add_state(());
     let mut symbol_position = 0;

--- a/src/transition_system/connected_components/scc.rs
+++ b/src/transition_system/connected_components/scc.rs
@@ -349,7 +349,7 @@ mod tests {
         let ts = NTS::builder()
             .default_color(())
             .with_transitions(&transitions)
-            .deterministic()
+            .into_dts()
             .with_initial(0);
         let sccs = ts.sccs();
         let first = sccs.first();

--- a/src/transition_system/dot.rs
+++ b/src/transition_system/dot.rs
@@ -698,14 +698,14 @@ mod tests {
     #[test]
     #[ignore]
     fn dot_render_dpa() {
-        let alphabet = alphabet!(simple 'a', 'b');
-        let mut dpa: DPA<alphabet::CharAlphabet> = DPA::new_for_alphabet(alphabet);
-        let q0 = dpa.initial();
-        let q1 = dpa.add_state(Void);
-        dpa.add_edge(q0, 'a', q0, 1usize);
-        dpa.add_edge(q0, 'b', q1, 2usize);
-        dpa.add_edge(q1, 'a', q1, 0usize);
-        dpa.add_edge(q1, 'b', q0, 2usize);
+        let dpa = TSBuilder::without_state_colors()
+            .with_edges([
+                (0, 'a', 1, 0),
+                (0, 'b', 2, 1),
+                (1, 'a', 0, 1),
+                (1, 'b', 2, 0),
+            ])
+            .into_dpa(0);
         dpa.display_rendered().unwrap();
     }
 }

--- a/src/transition_system/impls/dts.rs
+++ b/src/transition_system/impls/dts.rs
@@ -56,6 +56,12 @@ impl<A: Alphabet, Q: Clone, C: Clone> TransitionSystem for DTS<A, Q, C> {
     }
 }
 
+impl<A: Alphabet, Q: Clone, C: Clone> ForAlphabet<A> for DTS<A, Q, C> {
+    fn for_alphabet(from: A) -> Self {
+        Self(NTS::for_alphabet(from))
+    }
+}
+
 impl<A: Alphabet, Q: Clone, C: Clone> PredecessorIterable for DTS<A, Q, C> {
     type PreEdgeRef<'this> = &'this NTEdge<A::Expression, C>
     where
@@ -71,10 +77,6 @@ impl<A: Alphabet, Q: Clone, C: Clone> PredecessorIterable for DTS<A, Q, C> {
 }
 
 impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for DTS<A, Q, C> {
-    fn new_for_alphabet(alphabet: Self::Alphabet) -> Self {
-        Self(NTS::new_for_alphabet(alphabet))
-    }
-
     fn add_state<X: Into<StateColor<Self>>>(&mut self, color: X) -> Self::StateIndex {
         self.0.add_state(color)
     }

--- a/src/transition_system/impls/hash_ts.rs
+++ b/src/transition_system/impls/hash_ts.rs
@@ -293,8 +293,8 @@ where
             f,
             "{}",
             self.build_transition_table(
-                |idx, c| format!("{} : {:?}", idx, c),
-                |edge| format!("{:?}->{}", edge.color(), edge.target())
+                |idx, c| format!("{} : {:?}", idx.show(), c),
+                |edge| format!("{:?}->{}", edge.color(), edge.target().show())
             )
         )
     }
@@ -370,13 +370,6 @@ impl<A: Alphabet, Q: Clone, C: Clone + Hash + Eq> Sproutable for HashTs<A, Q, C,
             .set_color(color.into());
     }
 
-    fn new_for_alphabet(alphabet: Self::Alphabet) -> Self {
-        Self {
-            alphabet,
-            states: Map::default(),
-        }
-    }
-
     fn remove_edges<X: Indexes<Self>>(
         &mut self,
         from: X,
@@ -396,6 +389,15 @@ impl<A: Alphabet, Q: Clone, C: Clone + Hash + Eq> Sproutable for HashTs<A, Q, C,
             true
         } else {
             false
+        }
+    }
+}
+
+impl<A: Alphabet, Q: Clone + Hash + Eq, C: Clone + Hash + Eq> ForAlphabet<A> for HashTs<A, Q, C> {
+    fn for_alphabet(from: A) -> Self {
+        Self {
+            alphabet: from,
+            states: Map::default(),
         }
     }
 }

--- a/src/transition_system/impls/nts.rs
+++ b/src/transition_system/impls/nts.rs
@@ -26,15 +26,17 @@ pub struct NTS<A: Alphabet = CharAlphabet, Q = Void, C = Void> {
     edges: Vec<NTEdge<A::Expression, C>>,
 }
 
-impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for NTS<A, Q, C> {
-    fn new_for_alphabet(alphabet: Self::Alphabet) -> Self {
+impl<A: Alphabet, Q: Clone, C: Clone> ForAlphabet<A> for NTS<A, Q, C> {
+    fn for_alphabet(alphabet: Self::Alphabet) -> Self {
         Self {
             alphabet,
             states: vec![],
             edges: vec![],
         }
     }
+}
 
+impl<A: Alphabet, Q: Clone, C: Clone> Sproutable for NTS<A, Q, C> {
     fn add_state<X: Into<StateColor<Self>>>(&mut self, color: X) -> Self::StateIndex {
         let id = self.states.len();
         let state = NTState::new(color.into());
@@ -396,7 +398,7 @@ mod tests {
                 (1, 'a', 200, 0),
                 (1, 'b', 2000, 1),
             ])
-            .deterministic();
+            .into_dts();
         let second = TSBuilder::default()
             .with_state_colors([0, 1])
             .with_edges([
@@ -405,7 +407,7 @@ mod tests {
                 (0, 'a', 100u32, 0),
                 (1, 'a', 200, 0),
             ])
-            .deterministic();
+            .into_dts();
         assert!(first == second, "equality should disregard order of edges");
     }
 }

--- a/src/transition_system/operations/product.rs
+++ b/src/transition_system/operations/product.rs
@@ -410,13 +410,13 @@ mod tests {
         let l: MealyMachine = NTS::builder()
             .default_color(Void)
             .with_transitions([(0, 'a', 0, 0), (0, 'b', 0, 0)])
-            .deterministic()
+            .into_dts()
             .with_initial(0)
             .into_mealy();
         let r: MealyMachine = NTS::builder()
             .default_color(Void)
             .with_transitions([(0, 'a', 0, 0)])
-            .deterministic()
+            .into_dts()
             .with_initial(0)
             .into_mealy();
         assert!((&l).ts_product(&l).reached_state_index("b").is_some());

--- a/src/transition_system/operations/quotient.rs
+++ b/src/transition_system/operations/quotient.rs
@@ -260,7 +260,7 @@ impl<D: Deterministic> Deterministic for Quotient<D> {
                     "{{{}}}",
                     states.iter().map(|idx| idx.to_string()).join(", ")
                 );
-                panic!("From {origin}|{} on symbol {}, we reach {} while precisely one state should be reached!", self.class_iter_by_id(origin).unwrap().map(|c| c.to_string()).join(", "), symbol.show(), string)
+                panic!("From {origin}|{} on symbol {}, we reach {} while precisely one state should be reached!", self.class_iter_by_id(origin).unwrap().map(|c| c.show()).join(", "), symbol.show(), string)
             }
         }
     }

--- a/src/transition_system/operations/subset.rs
+++ b/src/transition_system/operations/subset.rs
@@ -171,7 +171,7 @@ where
                         .get(idx)
                         .unwrap()
                         .iter()
-                        .map(|q| q.to_string())
+                        .map(|q| q.show())
                         .join(", ")
                 ),
                 |edge| edge.target().to_string()
@@ -216,7 +216,7 @@ mod tests {
                 (1, 'b', 1),
                 (1, 'a', 0),
             ])
-            .nondeterministic()
+            .into_nts()
             .with_initial(0);
 
         let dts = nts.subset_construction();

--- a/src/transition_system/transitions_from.rs
+++ b/src/transition_system/transitions_from.rs
@@ -71,7 +71,8 @@ impl<'a, D: TransitionSystem + 'a> TransitionsFrom<'a, D> {
     pub fn new(det: &'a D, state: D::StateIndex) -> Self {
         let Some(edges) = det.edges_from(state) else {
             panic!(
-                "We should at least get an iterator. Probably the state {state} does not exist."
+                "We should at least get an iterator. Probably the state {} does not exist.",
+                state.show()
             );
         };
 

--- a/src/word/omega.rs
+++ b/src/word/omega.rs
@@ -127,7 +127,7 @@ pub trait OmegaWord<S>: LinearWord<S> {
     ///
     /// let ts = TSBuilder::without_colors()
     ///     .with_edges([(0, 'a', 1), (0, 'b', 0), (1, 'a', 0), (1, 'b', 1)])
-    ///     .deterministic()
+    ///     .into_dts()
     ///     .with_initial(0);
     /// let word = upw!("b", "a");
     /// let normalized = word.normalize_for(&ts).expect("must be normalizable");


### PR DESCRIPTION
This commit removes the `first()` method on `IndexType`. To do this, we also rework all collect methods and introduce a new `ForAlphabet<A>` trait, which indicates that a type can be constructed for a specific instance of an alphabet of type `A`.

There are some minor renamings to make everything more consistent. The `deterministic` and `nondeterministic` methods on `TSBuilder` were renamed to `into_dts()` and `into_nts()`.
Some collection methods on `Sproutable` were removed and some tests have been added.