### PR TITLE
Implement HOA parsing for colored DPAs, implement HOA output for DPAs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "ts"
 harness = false
+
+[[bin]]
+name = "oai"
+path = "bin/oai.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bit-set = "0.5"
 bimap = "0.6"
 fastrand = { version = "2", optional = true }
 hoars = { path = "hoars", optional = true }
+clap = { version = "4.5", optional = true }
 
 [features]
 default = ["hoa", "graphviz", "random", "minimize"]
@@ -25,6 +26,7 @@ random = ["fastrand"]
 minimize = []
 hoa = ["dep:hoars", "biodivine-lib-bdd"]
 graphviz = ["dep:tempfile"]
+oai-bin = ["clap"]
 
 [dev-dependencies]
 lazy_static = "1.4"
@@ -38,3 +40,4 @@ harness = false
 [[bin]]
 name = "oai"
 path = "bin/oai.rs"
+required-features = ["oai-bin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ biodivine-lib-bdd = { version = "0.5", optional = true }
 bit-set = "0.5"
 bimap = "0.6"
 fastrand = { version = "2", optional = true }
-hoars = { git = "https://github.com/leonbohn/hoars", optional = true }
+hoars = { path = "hoars", optional = true }
 
 [features]
 default = ["hoa", "graphviz", "random", "minimize"]

--- a/bin/oai.rs
+++ b/bin/oai.rs
@@ -1,0 +1,20 @@
+use automata::hoa::input::HoaAutomatonStream;
+use automata::prelude::*;
+
+use tracing::info;
+use tracing_subscriber::{filter, prelude::*};
+
+pub fn main() {
+    let stdout_log = tracing_subscriber::fmt::layer().pretty();
+
+    tracing_subscriber::registry()
+        .with(stdout_log.with_filter(filter::LevelFilter::TRACE))
+        .init();
+
+    info!("Reading from stdin");
+    let mut stream = HoaAutomatonStream::new(std::io::stdin().lock());
+
+    while let Some(aut) = stream.next() {
+        info!("Read automaton with {} states", aut.size());
+    }
+}

--- a/bin/oai.rs
+++ b/bin/oai.rs
@@ -8,7 +8,7 @@ use automata::{
 use tracing::{debug, info, trace};
 use tracing_subscriber::{filter, prelude::*};
 
-use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 fn cli() -> clap::Command {
     Command::new("oai")
@@ -68,6 +68,7 @@ pub fn main() {
                 info!("read deterministic automaton with {} states", aut.size());
 
                 let converted: DeterministicOmegaAutomaton<CharAlphabet> = aut.into();
+                trace!("first conversion successful");
                 let reconverted: DeterministicOmegaAutomaton<HoaAlphabet> =
                     converted.try_into().unwrap();
 

--- a/bin/oai.rs
+++ b/bin/oai.rs
@@ -8,7 +8,7 @@ use automata::{
 use tracing::{debug, info, trace};
 use tracing_subscriber::{filter, prelude::*};
 
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command};
 
 fn cli() -> clap::Command {
     Command::new("oai")
@@ -57,20 +57,30 @@ pub fn main() {
 
     setup_logging(&matches);
 
-    info!("reading automata from stdin");
+    debug!("reading automata from stdin");
     let mut stream = FilterDeterministicHoaAutomatonStream::new(std::io::stdin().lock());
 
     match matches.subcommand() {
-        Some(("todpa", sub_matches)) => {
-            info!("converting input automata into DPAs");
+        Some(("todpa", _sub_matches)) => {
+            debug!("converting input automata into DPAs");
 
             while let Some(aut) = stream.next() {
-                info!("read deterministic automaton with {} states", aut.size());
+                debug!("read deterministic automaton with {} states", aut.size());
 
+                let start = std::time::Instant::now();
                 let converted: DeterministicOmegaAutomaton<CharAlphabet> = aut.into();
-                trace!("first conversion successful");
+                info!(
+                    "conversion into char alphabet automaton took {}µs",
+                    start.elapsed().as_micros()
+                );
+
+                let start = std::time::Instant::now();
                 let reconverted: DeterministicOmegaAutomaton<HoaAlphabet> =
                     converted.try_into().unwrap();
+                info!(
+                    "conversion into HOA alphabet automaton took {}µs",
+                    start.elapsed().as_micros()
+                );
 
                 print!("{}", reconverted.into_dpa().to_hoa());
             }

--- a/hoars/.gitignore
+++ b/hoars/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/hoars/Cargo.toml
+++ b/hoars/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "hoars"
+license = "MIT"
+description = "A library for dealing with the HOA (Hanoi Omega Automata) file format."
+homepage = "https://github.com/leonbohn/lama/"
+repository = "https://github.com/leonbohn/lama/tree/main/hoars"
+readme = "README.md"
+keywords = ["omega-automata", "hoa", "automata"]
+categories = ["encoding", "parser-implementations"]
+version = "0.1.1"
+edition = "2021"
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = "0.3"
+ariadne = "0.4"
+chumsky = { version = "0.9", default-features = false, features = [
+    "ahash",
+    "std",
+] }
+itertools = "0.12"
+biodivine-lib-bdd = "0.5"
+lazy_static = "1.4.0"

--- a/hoars/README.md
+++ b/hoars/README.md
@@ -1,0 +1,13 @@
+# HOArs
+
+A parser for dealing with Hanoi Omega-Automata (HOA) file format, which is described in more detail [here](https://adl.github.io/hoaf/).
+At the moment, we can only parse HOA files, support for writing them will be added later.
+
+## Changelog
+### 0.1.1 (230414)
+Added lots and lots of documentation, some helper methods and introduced a
+method for converting label expressions to DNF, which in turn allows to
+use them as symbols for an automaton.
+
+### 0.1 (230216)
+First release 0.1 version, probably buggy as hell.

--- a/hoars/hoa/manysipmledpa.hoa
+++ b/hoars/hoa/manysipmledpa.hoa
@@ -1,0 +1,78 @@
+HOA: v1
+States: 2
+Start: 0
+acc-name: Rabin 1
+Acceptance: 2 (Fin(0) & Inf(1))
+AP: 2 "a" "b"
+--BODY--
+State: 0 "a U b"   /* An example of named state */
+[0 & !1] 0 {0}
+[1] 1 {0}
+State: 1
+[t] 1 {1}
+--END--
+HOA: v1
+States: 2
+Start: 0
+acc-name: Rabin 1
+Acceptance: 2 (Fin(0) & Inf(1))
+AP: 2 "a" "b"
+--BODY--
+State: 0 "a U b"   /* An example of named state */
+[0 & !1] 0 {0}
+[1] 1 {0}
+State: 1
+[t] 1 {1}
+--END--
+HOA: v1
+States: 2
+Start: 0
+acc-name: Rabin 1
+Acceptance: 2 (Fin(0) & Inf(1))
+AP: 2 "a" "b"
+--BODY--
+State: 0 "a U b"   /* An example of named state */
+[0 & !1] 0 {0}
+[1] 1 {0}
+State: 1
+[t] 1 {1}
+--END--
+HOA: v1
+States: 2
+Start: 0
+acc-name: Rabin 1
+Acceptance: 2 (Fin(0) & Inf(1))
+AP: 2 "a" "b"
+--BODY--
+State: 0 "a U b"   /* An example of named state */
+[0 & !1] 0 {0}
+[1] 1 {0}
+State: 1
+[t] 1 {1}
+--END--
+HOA: v1
+States: 2
+Start: 0
+acc-name: Rabin 1
+Acceptance: 2 (Fin(0) & Inf(1))
+AP: 2 "a" "b"
+--BODY--
+State: 0 "a U b"   /* An example of named state */
+[0 & !1] 0 {0}
+[1] 1 {0}
+State: 1
+[t] 1 {1}
+--END--
+HOA: v1
+States: 2
+Start: 0
+acc-name: Rabin 1
+Acceptance: 2 (Fin(0) & Inf(1))
+AP: 2 "a" "b"
+--BODY--
+State: 0 "a U b"   /* An example of named state */
+[0 & !1] 0 {0}
+[1] 1 {0}
+State: 1
+[t] 1 {1}
+--END--

--- a/hoars/hoa/simpledpa.hoa
+++ b/hoars/hoa/simpledpa.hoa
@@ -1,13 +1,14 @@
 HOA: v1
 States: 2
 Start: 0
-acc-name: Rabin 1
-Acceptance: 2 (Fin(0) & Inf(1))
-AP: 2 "a" "b"
+acc-name: parity min even 3
+Acceptance: 2 Inf(0) | (Fin(1) & Inf(2))
+AP: 1 "a"
 --BODY--
 State: 0 "a U b"   /* An example of named state */
-[0 & !1] 0 {0}
-[1] 1 {0}
+[0] 0 {1}
+[!0] 1 {2}
 State: 1
-[t] 1 {1}
+[0] 1 {0}
+[!0] 0 {2}
 --END--

--- a/hoars/hoa/simpledpa.hoa
+++ b/hoars/hoa/simpledpa.hoa
@@ -1,0 +1,13 @@
+HOA: v1
+States: 2
+Start: 0
+acc-name: Rabin 1
+Acceptance: 2 (Fin(0) & Inf(1))
+AP: 2 "a" "b"
+--BODY--
+State: 0 "a U b"   /* An example of named state */
+[0 & !1] 0 {0}
+[1] 1 {0}
+State: 1
+[t] 1 {1}
+--END--

--- a/hoars/src/body.rs
+++ b/hoars/src/body.rs
@@ -1,16 +1,18 @@
 use std::ops::{Deref, DerefMut};
 
-use biodivine_lib_bdd::Bdd;
 use chumsky::prelude::*;
 
-use crate::{lexer::Token, value, AcceptanceSignature, AtomicProposition, Id, StateConjunction};
+use crate::{
+    lexer::Token, value, AbstractLabelExpression, AcceptanceSignature, AtomicProposition, Id,
+    StateConjunction,
+};
 
 /// Newtype wrapper around a [`crate::LabelExpression`], implements [`Deref`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Label(pub Bdd);
+pub struct Label(pub AbstractLabelExpression);
 
 impl Deref for Label {
-    type Target = Bdd;
+    type Target = AbstractLabelExpression;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/hoars/src/body.rs
+++ b/hoars/src/body.rs
@@ -1,0 +1,316 @@
+use std::ops::{Deref, DerefMut};
+
+use biodivine_lib_bdd::Bdd;
+use chumsky::prelude::*;
+
+use crate::{lexer::Token, value, AcceptanceSignature, AtomicProposition, Id, StateConjunction};
+
+/// Newtype wrapper around a [`crate::LabelExpression`], implements [`Deref`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Label(pub Bdd);
+
+impl Deref for Label {
+    type Target = Bdd;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Alphabet(pub Vec<AtomicProposition>);
+
+#[derive(Clone, Debug)]
+pub struct RawState(
+    Option<Label>,
+    Id,
+    Option<String>,
+    Option<AcceptanceSignature>,
+);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExplicitEdge(Label, StateConjunction, Option<AcceptanceSignature>);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ImplicitEdge(StateConjunction, Option<AcceptanceSignature>);
+
+/// Represents an edge in a HOA automaton. It contains the [`crate::LabelExpression`], the
+/// [`StateConjunction`] and the [`AcceptanceSignature`] of the edge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Edge(
+    pub(crate) Label,
+    pub(crate) StateConjunction,
+    pub(crate) AcceptanceSignature,
+);
+
+impl Edge {
+    /// Returns the label of the edge.
+    pub fn label(&self) -> &Label {
+        &self.0
+    }
+
+    /// Gives mutable access to the label of the edge.
+    pub fn label_mut(&mut self) -> &mut Label {
+        &mut self.0
+    }
+
+    /// Returns the state conjunction of the edge.
+    pub fn state_conjunction(&self) -> &StateConjunction {
+        &self.1
+    }
+
+    /// Returns the acceptance signature of the edge.
+    pub fn acceptance_signature(&self) -> &AcceptanceSignature {
+        &self.2
+    }
+
+    /// Tries to get the target (singular) of the transition. Returns `None` if the
+    /// transition does not have a singular target.
+    pub fn target(&self) -> Option<Id> {
+        self.1.get_singleton()
+    }
+
+    /// Builds an edge from its parts.
+    pub fn from_parts(
+        label_expression: Label,
+        state_conjunction: StateConjunction,
+        acceptance_signature: AcceptanceSignature,
+    ) -> Self {
+        Self(label_expression, state_conjunction, acceptance_signature)
+    }
+}
+
+/// Represents a state in a HOA automaton. It contains the [`Id`] of the state, an optional
+/// comment and a list of outgoing edges.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct State(
+    pub(crate) Id,
+    pub(crate) Option<String>,
+    pub(crate) Vec<Edge>,
+);
+
+impl State {
+    /// Constructs a new state from its parts.
+    pub fn from_parts(id: Id, comment: Option<String>, edges: Vec<Edge>) -> Self {
+        Self(id, comment, edges)
+    }
+
+    /// Extracts the id of the state.
+    pub fn id(&self) -> Id {
+        self.0
+    }
+
+    /// Extracts the comment of the state, if present.
+    pub fn comment(&self) -> Option<&str> {
+        self.1.as_deref()
+    }
+
+    /// Extracts the edges of the state.
+    pub fn edges(&self) -> &[Edge] {
+        &self.2
+    }
+
+    /// Gives mutable access to the edges of this state.
+    pub fn edges_mut(&mut self) -> &mut [Edge] {
+        &mut self.2
+    }
+}
+
+impl From<(Option<AcceptanceSignature>, ExplicitEdge)> for Edge {
+    fn from((state_acc, edge): (Option<AcceptanceSignature>, ExplicitEdge)) -> Self {
+        let acc = match (state_acc, &edge.2) {
+            (None, None) => AcceptanceSignature(Vec::new()),
+            (Some(acc), None) => acc,
+            (None, Some(acc)) => acc.clone(),
+            (Some(left), Some(right)) => {
+                AcceptanceSignature(left.iter().cloned().chain(right.iter().cloned()).collect())
+            }
+        };
+        Edge(edge.0, edge.1, acc)
+    }
+}
+
+impl TryFrom<(RawState, Vec<ExplicitEdge>)> for State {
+    type Error = String;
+
+    fn try_from((state, edges): (RawState, Vec<ExplicitEdge>)) -> Result<Self, Self::Error> {
+        let mut out_edges = vec![];
+        let RawState(state_label, id, state_text, state_acc) = state;
+
+        if state_label.is_some() {
+            return Err("Transformation from state-based to transition-based requires adding a new initial state etc (see example 'non-deterministic state-based Büchi Automaton')".to_string());
+        }
+
+        for raw_edge in edges {
+            out_edges.push(Edge::from((state_acc.clone(), raw_edge)));
+        }
+
+        Ok(State(id, state_text, out_edges))
+    }
+}
+
+pub fn label() -> impl Parser<Token, Label, Error = Simple<Token>> {
+    just(Token::Paren('['))
+        .ignore_then(value::label_expression())
+        .then_ignore(just(Token::Paren(']')))
+        .map(Label)
+}
+
+fn explicit_edge() -> impl Parser<Token, ExplicitEdge, Error = Simple<Token>> {
+    label()
+        .then(value::state_conjunction())
+        .then(value::acceptance_signature().or_not())
+        .map(|((label, state_conjunction), acceptance_signature)| {
+            ExplicitEdge(label, state_conjunction, acceptance_signature)
+        })
+}
+
+#[allow(unused)]
+fn implicit_edge() -> impl Parser<Token, ImplicitEdge, Error = Simple<Token>> {
+    value::state_conjunction()
+        .then(value::acceptance_signature().or_not())
+        .map(|(label, acceptance_signature)| ImplicitEdge(label, acceptance_signature))
+}
+
+pub fn state() -> impl Parser<Token, State, Error = Simple<Token>> {
+    just(Token::Header("State".to_string()))
+        .ignore_then(
+            label()
+                .or_not()
+                .then(value::integer())
+                .then(value::text().or_not())
+                .then(value::acceptance_signature().or_not())
+                .map(|(((l, i), t), a)| RawState(l, i, t, a)),
+        )
+        .then(explicit_edge().repeated())
+        .try_map(|input, span| State::try_from(input).map_err(|err| Simple::custom(span, err)))
+}
+
+/// Represents the body of a HOA automaton. In essence, this is just a vector of [`State`]s.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Body(Vec<State>);
+
+impl<'a> IntoIterator for &'a Body {
+    type Item = &'a State;
+
+    type IntoIter = std::slice::Iter<'a, State>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl Body {
+    /// Constructs a new empty body.
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub(crate) fn parser() -> impl Parser<Token, Self, Error = Simple<Token>> {
+        just(Token::BodyStart)
+            .ignore_then(state().repeated())
+            .map(Body)
+            .then_ignore(just(Token::BodyEnd))
+    }
+}
+
+impl From<Vec<State>> for Body {
+    fn from(value: Vec<State>) -> Self {
+        Body(value)
+    }
+}
+
+impl Deref for Body {
+    type Target = Vec<State>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Body {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chumsky::{primitive::end, Parser, Stream};
+
+    use crate::{lexer, Edge, Label, StateConjunction, ALPHABET, VARS};
+
+    use super::State;
+
+    pub fn in_tags(input: &str) -> String {
+        format!("--BODY--\n{}\n--END--", input)
+    }
+
+    #[cfg(test)]
+    pub fn process_body(input: &str) -> Result<Vec<State>, ()> {
+        use crate::{body::Body, print_error_report};
+
+        let tokens = lexer::tokenizer().parse(input).map_err(|error_list| {
+            print_error_report(
+                input,
+                error_list.into_iter().map(|err| err.map(|c| c.to_string())),
+            )
+        })?;
+
+        for tok in &tokens {
+            print!("{}", tok.0);
+        }
+        let len = input.chars().count();
+        let ast = Body::parser()
+            .then_ignore(end())
+            .parse(Stream::from_iter(len..len + 1, tokens.into_iter()))
+            .map_err(|error_list| {
+                print_error_report(
+                    input,
+                    error_list.into_iter().map(|err| err.map(|c| c.to_string())),
+                )
+            })?;
+        Ok(ast.0)
+    }
+
+    #[test]
+    fn two_explicit_transitions_with_comment() {
+        let hoa = r#"State: 0 "a U b"   /* An example of named state */
+        [0 & !1] 0 {0}
+        [1] 1 {0}"#;
+        let t0 = Edge::from_parts(
+            Label(ALPHABET.mk_var(VARS[0]).and(&ALPHABET.mk_not_var(VARS[1]))),
+            StateConjunction(vec![0]),
+            crate::AcceptanceSignature(vec![0]),
+        );
+        let t1 = Edge::from_parts(
+            Label(ALPHABET.mk_var(VARS[1])),
+            StateConjunction(vec![1]),
+            crate::AcceptanceSignature(vec![0]),
+        );
+        let q0 = State::from_parts(0, Some("a U b".to_string()), vec![t0, t1]);
+        assert_eq!(process_body(&in_tags(hoa)), Ok(vec![q0]));
+    }
+
+    #[test]
+    fn one_transition_label_true() {
+        let hoa = r#"
+            State: 1
+            [t] 1 {1}
+        "#;
+        let t0 = Edge::from_parts(
+            Label(ALPHABET.mk_true()),
+            StateConjunction(vec![1]),
+            crate::AcceptanceSignature(vec![1]),
+        );
+        let q0 = State::from_parts(1, None, vec![t0]);
+        assert_eq!(process_body(&in_tags(hoa)), Ok(vec![q0]));
+    }
+
+    #[test]
+    fn no_transition_state() {
+        let hoa = r#"State: 1"#;
+        let q0 = State::from_parts(1, None, vec![]);
+        assert_eq!(process_body(&in_tags(hoa)), Ok(vec![q0]));
+    }
+}

--- a/hoars/src/format.rs
+++ b/hoars/src/format.rs
@@ -1,0 +1,325 @@
+use std::{
+    borrow::Borrow,
+    fmt::Display,
+    ops::{Deref, Rem},
+};
+
+use crate::Id;
+
+/// Represents a conjunction over states of a HOA automaton, this
+/// is mostly used as the initial state of the automaton.
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct StateConjunction(pub(crate) Vec<crate::Id>);
+
+impl StateConjunction {
+    /// Attempts to get the singleton element of the state conjunction, if it exists.
+    /// Returns `None` if the state conjunction is not a singleton.
+    /// This is useful when dealing with non-alternating automata.
+    pub fn get_singleton(&self) -> Option<Id> {
+        if self.0.len() == 1 {
+            Some(self.0[0])
+        } else {
+            None
+        }
+    }
+
+    /// Creates a state conjunction containing a single id.
+    pub fn singleton(id: Id) -> Self {
+        Self(vec![id])
+    }
+}
+
+/// An atomic proposition is named by a string.
+pub type AtomicProposition = String;
+
+/// Aliases are also named by a string.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct AliasName(pub(crate) String);
+
+/// An acceptance atom can be used to build an acceptance condition,
+/// each atom is either a positive or a negative acceptance set
+/// identifier.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[allow(missing_docs)]
+pub enum AcceptanceAtom {
+    Positive(Id),
+    Negative(Id),
+}
+
+/// An acceptance signature is a vector of acceptance set
+/// identifiers, it is associated with an edge.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct AcceptanceSignature(pub(crate) Vec<crate::Id>);
+
+impl AcceptanceSignature {
+    /// Tries to get the singleton element of the acceptance signature, if it exists.
+    /// Returns `None` if the acceptance signature is not a singleton.
+    pub fn get_singleton(&self) -> Option<Option<Id>> {
+        if self.len() == 0 {
+            Some(None)
+        } else if self.len() == 1 {
+            Some(Some(self[0]))
+        } else {
+            None
+        }
+    }
+
+    /// Creates an acceptance signature containing a single id.
+    pub fn from_singleton(singleton: Id) -> Self {
+        Self(vec![singleton])
+    }
+
+    /// Creates an empty acceptance signature.
+    pub fn empty() -> Self {
+        Self(vec![])
+    }
+}
+
+impl Deref for AcceptanceSignature {
+    type Target = Vec<crate::Id>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Represents a boolean value in the HOA format.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Ord, PartialOrd)]
+pub struct HoaBool(pub bool);
+
+/// An acceptance condition is a positive boolean expression over
+/// [`AcceptanceAtom`]s.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum AcceptanceCondition {
+    /// Represents that the given atom should appear finitely often.
+    Fin(AcceptanceAtom),
+    /// The given atom should appear infinitely often.
+    Inf(AcceptanceAtom),
+    /// Represents a conjunction of two acceptance conditions.
+    And(Box<AcceptanceCondition>, Box<AcceptanceCondition>),
+    /// Represents a disjunction of two acceptance conditions.
+    Or(Box<AcceptanceCondition>, Box<AcceptanceCondition>),
+    /// A constant boolean value.
+    Boolean(HoaBool),
+}
+
+impl AcceptanceCondition {
+    fn parity_rec(current: u32, total: u32) -> Self {
+        if current + 1 >= total {
+            if current.rem(2) == 0 {
+                AcceptanceCondition::id_inf(current)
+            } else {
+                AcceptanceCondition::id_fin(current)
+            }
+        } else if current.rem(2) == 0 {
+            AcceptanceCondition::Or(
+                Box::new(AcceptanceCondition::Inf(AcceptanceAtom::Positive(current))),
+                Box::new(Self::parity_rec(current + 1, total)),
+            )
+        } else {
+            AcceptanceCondition::And(
+                Box::new(AcceptanceCondition::Fin(AcceptanceAtom::Positive(current))),
+                Box::new(Self::parity_rec(current + 1, total)),
+            )
+        }
+    }
+
+    /// Creates a parity acceptance condition with the given number of priorities.
+    pub fn parity(priorities: u32) -> Self {
+        Self::parity_rec(0, priorities)
+    }
+
+    /// Creates a Buchi acceptance condition.
+    pub fn buchi() -> Self {
+        AcceptanceCondition::Inf(AcceptanceAtom::Positive(0))
+    }
+
+    /// Creates a conjunction of two acceptance conditions.
+    pub fn and<C: Borrow<AcceptanceCondition>>(&self, other: C) -> Self {
+        AcceptanceCondition::And(Box::new(self.clone()), Box::new(other.borrow().clone()))
+    }
+
+    /// Creates a disjunction of two acceptance conditions.
+    pub fn or<C: Borrow<AcceptanceCondition>>(&self, other: C) -> Self {
+        AcceptanceCondition::Or(Box::new(self.clone()), Box::new(other.borrow().clone()))
+    }
+
+    /// Creates an acceptance condition containing the given atom.
+    pub fn atom<A: Borrow<AcceptanceAtom>>(atom: A) -> Self {
+        AcceptanceCondition::Fin(atom.borrow().clone())
+    }
+
+    /// Creates an acceptance condition consisting of a positive atodm.
+    pub fn id_fin(id: Id) -> Self {
+        Self::Fin(AcceptanceAtom::Positive(id))
+    }
+
+    /// Creates an acceptance condition consisting of a negative atom.
+    pub fn id_inf(id: Id) -> Self {
+        Self::Inf(AcceptanceAtom::Positive(id))
+    }
+}
+
+/// Represents the name of a type of acceptance condition.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum AcceptanceName {
+    /// Büchi acceptance, implies that there is only one
+    /// acceptance set. Is satisfied if an edge/state of the
+    /// acceptance set appears infinitely often.
+    Buchi,
+    /// Generalized Büchi consists of multiple Büchi acceptance
+    /// conditions. It is satisfied if all of the Büchi conditions
+    /// are satsified.
+    GeneralizedBuchi,
+    /// Co-Büchi conditions are dual to Büchi conditions, they are
+    /// satisfied if no edge/state from the acceptance set appears
+    /// infinitely often.
+    CoBuchi,
+    /// Generalized co-Büchi conditions are dual to generalized
+    /// Büchi conditions, see [`AcceptanceName::GeneralizedBuchi`].
+    GeneralizedCoBuchi,
+    /// A Streett condition consists of a set of pairs of acceptance
+    /// sets. It is dual to a [`AcceptanceName::Rabin`] condition
+    /// and satisfied if for each pair (X, Y) in the condition holds
+    /// that if X appears infinitely often, then Y also appears
+    /// infinitely often.
+    Streett,
+    /// A Rabin condition is dual to a [`AcceptanceName::Streett`]
+    /// condition, it also consists of a set of pairs (X,Y) of
+    /// acceptance sets. It is satisfied if there exists a pair
+    /// (X, Y) in the condition such that no set from X appears
+    /// infinitely often and one set from Y appears infinitely
+    /// often.
+    Rabin,
+    /// A generalized Rabin condition is a set of [`AcceptanceName::Rabin`]
+    /// conditions and it is satisfied of all of the Rabin conditions
+    /// are satisfied.
+    GeneralizedRabin,
+    /// A parity (or Mostowski) condition associates with each
+    /// state/transition a priority, i.e. a non-negative integer.
+    /// It is satisfied if the least priority that appears infinitely
+    /// often is even. There is also max even, min odd and max odd
+    /// variants of this condition, but they are all equivalent
+    /// in terms of expressiveness.
+    Parity,
+    /// Represents a condition where everything is accepted.
+    All,
+    /// A condition where nothing is accepted.
+    None,
+}
+
+impl AcceptanceName {
+    pub fn is_parity(&self) -> bool {
+        matches!(self, AcceptanceName::Parity)
+    }
+}
+
+impl TryFrom<String> for AcceptanceName {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "Buchi" => Ok(AcceptanceName::Buchi),
+            "generalized-Buchi" => Ok(AcceptanceName::GeneralizedBuchi),
+            "co-Buchi" => Ok(AcceptanceName::CoBuchi),
+            "generalized-co-Buchi" => Ok(AcceptanceName::GeneralizedCoBuchi),
+            "Streett" => Ok(AcceptanceName::Streett),
+            "Rabin" => Ok(AcceptanceName::Rabin),
+            "generalized-Rabin" => Ok(AcceptanceName::GeneralizedRabin),
+            "parity" => Ok(AcceptanceName::Parity),
+            "all" => Ok(AcceptanceName::All),
+            "none" => Ok(AcceptanceName::None),
+            val => Err(format!("Unknown acceptance type: {}", val)),
+        }
+    }
+}
+
+/// Represents properties of an automaton. For more information
+/// see the documentation of the [HOA format](https://adl.github.io/hoaf/#properties).
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[allow(missing_docs)]
+pub enum Property {
+    StateLabels,
+    TransLabels,
+    ImplicitLabels,
+    ExplicitLabels,
+    StateAcceptance,
+    TransitionAcceptance,
+    UniversalBranching,
+    NoUniversalBranching,
+    Deterministic,
+    Complete,
+    Unambiguous,
+    StutterInvariant,
+    Weak,
+    VeryWeak,
+    InherentlyWeak,
+    Terminal,
+    Tight,
+    Colored,
+}
+
+impl TryFrom<String> for Property {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "state-labels" => Ok(Property::StateLabels),
+            "trans-labels" => Ok(Property::TransLabels),
+            "implicit-labels" => Ok(Property::ImplicitLabels),
+            "explicit-labels" => Ok(Property::ExplicitLabels),
+            "state-acc" => Ok(Property::StateAcceptance),
+            "trans-acc" => Ok(Property::TransitionAcceptance),
+            "univ-branch" => Ok(Property::UniversalBranching),
+            "no-univ-branch" => Ok(Property::NoUniversalBranching),
+            "deterministic" => Ok(Property::Deterministic),
+            "complete" => Ok(Property::Complete),
+            "unambiguous" => Ok(Property::Unambiguous),
+            "stutter-invariant" => Ok(Property::StutterInvariant),
+            "weak" => Ok(Property::Weak),
+            "very-weak" => Ok(Property::VeryWeak),
+            "inherently-weak" => Ok(Property::InherentlyWeak),
+            "terminatl" => Ok(Property::Terminal),
+            "tight" => Ok(Property::Tight),
+            "colored" => Ok(Property::Colored),
+            unknown => Err(format!("{} is not a valid property", unknown)),
+        }
+    }
+}
+
+/// Used to give additional (human-readable) and optional
+/// information about the acceptance condition, more information
+/// can be obtained in the [HOA docs](https://adl.github.io/hoaf/#acc-name).
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[allow(missing_docs)]
+pub enum AcceptanceInfo {
+    Int(crate::Id),
+    Identifier(String),
+}
+
+impl AcceptanceInfo {
+    /// Creates an [`AcceptanceInfo`] from a [`Display`]able.
+    pub fn identifier<D: Display>(id: D) -> Self {
+        AcceptanceInfo::Identifier(id.to_string())
+    }
+
+    /// Creates an [`AcceptanceInfo`] from an [`Id`].
+    pub fn integer(id: Id) -> Self {
+        AcceptanceInfo::Int(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AcceptanceCondition;
+
+    #[test]
+    fn parity_acceptance_creator() {
+        let parity_condition = super::AcceptanceCondition::parity(3);
+        assert_eq!(
+            parity_condition,
+            AcceptanceCondition::id_inf(0)
+                .or(AcceptanceCondition::id_fin(1).and(AcceptanceCondition::id_inf(2)))
+        );
+    }
+}

--- a/hoars/src/header.rs
+++ b/hoars/src/header.rs
@@ -4,8 +4,8 @@ use chumsky::prelude::*;
 
 use crate::{
     format::{AtomicProposition, StateConjunction},
-    value, AcceptanceCondition, AcceptanceInfo, AcceptanceName, AliasName, Id, LabelExpression,
-    Property, Token,
+    value, AbstractLabelExpression, AcceptanceCondition, AcceptanceInfo, AcceptanceName, AliasName,
+    Id, Property, Token,
 };
 
 /// Represents a header item in a HOA file, for more information on each
@@ -23,7 +23,7 @@ pub enum HeaderItem {
     /// (1) Gives the atomic propositions of the automaton.
     AP(Vec<AtomicProposition>),
     /// (>=0) Allows the introduction of an alias for a label expression.
-    Alias(AliasName, LabelExpression),
+    Alias(AliasName, AbstractLabelExpression),
     /// (1) Gives the acceptance condition of the automaton.
     Acceptance(Id, AcceptanceCondition),
     /// (>=0) Gives the acceptance sets of the automaton.

--- a/hoars/src/header.rs
+++ b/hoars/src/header.rs
@@ -1,0 +1,400 @@
+use std::ops::{Deref, DerefMut};
+
+use chumsky::prelude::*;
+
+use crate::{
+    format::{AtomicProposition, StateConjunction},
+    value, AcceptanceCondition, AcceptanceInfo, AcceptanceName, AliasName, Id, LabelExpression,
+    Property, Token,
+};
+
+/// Represents a header item in a HOA file, for more information on each
+/// element, see the [HOA format specification](https://adl.github.io/hoaf/).
+/// The multiplicity of each element is given in parenthesis.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum HeaderItem {
+    /// The version of the HOA format.
+    Version(String),
+    /// (0|1) State header, gives the number of states in the automaton.
+    States(Id),
+    /// (>=0) Gives a conjunction of states that are the start states of the
+    /// automaton. May be specified multiple times.
+    Start(StateConjunction),
+    /// (1) Gives the atomic propositions of the automaton.
+    AP(Vec<AtomicProposition>),
+    /// (>=0) Allows the introduction of an alias for a label expression.
+    Alias(AliasName, LabelExpression),
+    /// (1) Gives the acceptance condition of the automaton.
+    Acceptance(Id, AcceptanceCondition),
+    /// (>=0) Gives the acceptance sets of the automaton.
+    AcceptanceName(AcceptanceName, Vec<AcceptanceInfo>),
+    /// (0|1) Correspond to tool name and optional version number.
+    Tool(String, Option<String>),
+    /// (0|1) Correspond to the name of the automaton.
+    Name(String),
+    /// (>=0) Gives the properties of the automaton.
+    Properties(Vec<Property>),
+}
+
+impl HeaderItem {
+    pub fn count_states(&self) -> Option<usize> {
+        if let HeaderItem::States(i) = self {
+            Some(*i as usize)
+        } else {
+            None
+        }
+    }
+
+    pub fn try_acceptance_name(&self) -> Option<(&AcceptanceName, &[AcceptanceInfo])> {
+        if let HeaderItem::AcceptanceName(x, y) = self {
+            Some((x, y))
+        } else {
+            None
+        }
+    }
+
+    pub fn count_acceptance_sets(&self) -> Option<usize> {
+        if let HeaderItem::Acceptance(n, _) = self {
+            Some(*n as usize)
+        } else {
+            None
+        }
+    }
+}
+
+impl HeaderItem {
+    /// Creates a new version 1 header item.
+    pub fn v1() -> Self {
+        HeaderItem::Version("v1".to_string())
+    }
+}
+
+fn item() -> impl Parser<Token, HeaderItem, Error = Simple<Token>> {
+    let states = just(Token::Header("States".to_string()))
+        .ignore_then(value::integer())
+        .map(HeaderItem::States);
+
+    let acceptance_name = just(Token::Header("acc-name".to_string()))
+        .ignore_then(value::identifier())
+        .try_map(|identifier, span| {
+            AcceptanceName::try_from(identifier).map_err(|e| Simple::custom(span, e))
+        })
+        .then(value::acceptance_info().repeated())
+        .map(|(name, info)| HeaderItem::AcceptanceName(name, info));
+
+    let start = just(Token::Header("Start".to_string()))
+        .ignore_then(value::integer().separated_by(just(Token::Op('&'))))
+        .map(|conjunction| HeaderItem::Start(StateConjunction(conjunction)));
+
+    let aps = just(Token::Header("AP".to_string()))
+        .ignore_then(value::integer())
+        .then(value::text().repeated())
+        .try_map(|(num, prop_labels), span| {
+            if (num as usize) == prop_labels.len() {
+                Ok(HeaderItem::AP(prop_labels))
+            } else {
+                Err(Simple::custom(
+                    span,
+                    format!("Expected {} aps but got {}", num, prop_labels.len()),
+                ))
+            }
+        });
+
+    let acceptance = just(Token::Header("Acceptance".to_string()))
+        .ignore_then(value::integer())
+        .then(value::acceptance_condition())
+        .map(|(count, condition)| HeaderItem::Acceptance(count, condition));
+
+    let alias = just(Token::Header("Alias".to_string()))
+        .ignore_then(value::alias_name())
+        .then(value::label_expression())
+        .map(|(aname, expression)| HeaderItem::Alias(AliasName(aname), expression));
+
+    let name = just(Token::Header("name".to_string()))
+        .ignore_then(value::text())
+        .map(HeaderItem::Name);
+
+    let tool = just(Token::Header("tool".to_string()))
+        .ignore_then(value::text())
+        .then(value::text().or_not())
+        .map(|(tool, version)| HeaderItem::Tool(tool, version));
+
+    let properties = just(Token::Header("properties".to_string()))
+        .ignore_then(
+            value::identifier()
+                .try_map(|p, span| Property::try_from(p).map_err(|err| Simple::custom(span, err)))
+                .repeated()
+                .at_least(1),
+        )
+        .map(HeaderItem::Properties);
+
+    chumsky::primitive::choice((
+        states,
+        acceptance,
+        acceptance_name,
+        start,
+        aps,
+        alias,
+        name,
+        tool,
+        properties,
+    ))
+}
+
+/// Represents the header of a HOA file, consists of a set of [`HeaderItem`]s.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Header(Vec<HeaderItem>);
+
+impl From<Vec<HeaderItem>> for Header {
+    fn from(value: Vec<HeaderItem>) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> IntoIterator for &'a Header {
+    type Item = &'a HeaderItem;
+
+    type IntoIter = std::slice::Iter<'a, HeaderItem>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl Header {
+    /// Construts a new header parser.
+    pub fn parser() -> impl Parser<Token, Self, Error = Simple<Token>> {
+        let version = just(Token::Header("HOA".to_string()))
+            .ignore_then(value::identifier())
+            .map(HeaderItem::Version);
+        version
+            .then(item().repeated())
+            .map(|(version, headers)| Header(std::iter::once(version).chain(headers).collect()))
+    }
+
+    /// Constructs a new header from a vector of header items.
+    pub fn from_vec(value: Vec<HeaderItem>) -> Self {
+        Self(value)
+    }
+
+    /// Returns the version of the format.
+    pub fn get_version(&self) -> Option<String> {
+        self.iter().find_map(|item| match item {
+            HeaderItem::Version(version) => Some(version.clone()),
+            _ => None,
+        })
+    }
+
+    pub fn count_states(&self) -> Option<usize> {
+        self.iter().find_map(|i| i.count_states())
+    }
+
+    pub fn acceptance_name(&self) -> AcceptanceName {
+        self.iter()
+            .find_map(|i| i.try_acceptance_name())
+            .expect("Acceptance header must be present")
+            .0
+            .clone()
+    }
+}
+
+impl Deref for Header {
+    type Target = Vec<HeaderItem>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Header {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(test)]
+    #[allow(clippy::unnecessary_unwrap)]
+    pub fn process_header(input: &str) -> Result<Vec<HeaderItem>, String> {
+        use chumsky::Stream;
+
+        use crate::{build_error_report, lexer};
+
+        let with_hoa = format!("HOA: v1\n{}", input);
+
+        let (tokens, errs) = lexer::tokenizer().parse_recovery(with_hoa);
+        if let Some(tokens) = tokens {
+            let len = input.chars().count();
+            let (ast, parse_errs) = Header::parser()
+                .then_ignore(end())
+                .parse_recovery(Stream::from_iter(len..len + 1, tokens.into_iter()));
+
+            if parse_errs.is_empty() && ast.is_some() {
+                let out = ast.unwrap();
+                Ok(out.0)
+            } else {
+                Err(build_error_report(
+                    input,
+                    errs.into_iter()
+                        .map(|err| err.map(|c| c.to_string()))
+                        .chain(parse_errs.into_iter().map(|err| err.map(|c| c.to_string()))),
+                ))
+            }
+        } else {
+            Err(build_error_report(
+                input,
+                errs.into_iter().map(|err| err.map(|c| c.to_string())),
+            ))
+        }
+    }
+
+    use super::*;
+
+    fn assert_header(input: &str, cmp: &[HeaderItem]) {
+        match process_header(input) {
+            Ok(res) => assert_eq!(res, cmp),
+            Err(err) => {
+                eprintln!("{}", err);
+                unreachable!()
+            }
+        }
+    }
+
+    fn assert_fails(input: &str) {
+        assert!(process_header(input).is_err())
+    }
+
+    #[test]
+    fn property() {
+        assert_header(
+            r#"properties: trans-labels state-labels"#,
+            &[
+                HeaderItem::Version("v1".to_string()),
+                HeaderItem::Properties(vec![Property::TransLabels, Property::StateLabels]),
+            ],
+        );
+        assert_fails(r#"properties: trans-labels statelabels"#);
+        assert_fails(r#"properties: "#);
+    }
+
+    #[test]
+    fn tool_and_name() {
+        assert_header(
+            r#"
+                tool: "ltl-translate" "1.2-alpha"
+                name: "BA for GFa & GFb"
+            "#,
+            &[
+                HeaderItem::Version("v1".to_string()),
+                HeaderItem::Tool("ltl-translate".to_string(), Some("1.2-alpha".to_string())),
+                HeaderItem::Name("BA for GFa & GFb".to_string()),
+            ],
+        );
+        assert_fails("tool: ltl-translate \"1.2-alpha\"");
+    }
+
+    #[test]
+    fn ariadne() {
+        assert_header(
+            "acc-name: Rabin 3",
+            &[
+                HeaderItem::Version("v1".to_string()),
+                HeaderItem::AcceptanceName(AcceptanceName::Rabin, vec![AcceptanceInfo::Int(3)]),
+            ],
+        );
+        assert_header(
+            "Start: 0 & 7",
+            &[
+                HeaderItem::Version("v1".to_string()),
+                HeaderItem::Start(StateConjunction(vec![0, 7])),
+            ],
+        );
+    }
+
+    #[test]
+    fn aps() {
+        assert_header(
+            r#"AP: 3 "a" "proc@state" "a[x] >= 2""#,
+            &[
+                HeaderItem::Version("v1".to_string()),
+                HeaderItem::AP(vec![
+                    "a".to_string(),
+                    "proc@state".to_string(),
+                    "a[x] >= 2".to_string(),
+                ]),
+            ],
+        )
+    }
+
+    // #[test]
+    // fn alias() {
+    // assert_header(
+    //     "Alias: @a 0",
+    //     &[
+    //         HeaderItem::Version("v1".to_string()),
+    //         HeaderItem::Alias(AliasName("a".to_string()), LabelExpression::Integer(0)),
+    //     ],
+    // );
+    //     assert_header(
+    //         "Alias: @a 0 & 1",
+    //         &[
+    //             HeaderItem::Version("v1".to_string()),
+    //             HeaderItem::Alias(
+    //                 AliasName("a".to_string()),
+    //                 LabelExpression::And(
+    //                     Box::new(LabelExpression::Integer(0)),
+    //                     Box::new(LabelExpression::Integer(1)),
+    //                 ),
+    //             ),
+    //         ],
+    //     );
+
+    //     // & binds stronger
+    //     assert_header(
+    //         "Alias: @a 1 | 2 & 0",
+    //         &[
+    //             HeaderItem::Version("v1".to_string()),
+    //             HeaderItem::Alias(
+    //                 AliasName("a".to_string()),
+    //                 LabelExpression::Or(
+    //                     Box::new(LabelExpression::Integer(1)),
+    //                     Box::new(LabelExpression::And(
+    //                         Box::new(LabelExpression::Integer(2)),
+    //                         Box::new(LabelExpression::Integer(0)),
+    //                     )),
+    //                 ),
+    //             ),
+    //         ],
+    //     );
+    //     assert_header(
+    //         "Alias: @a 0 & 1 | 2",
+    //         &[
+    //             HeaderItem::Version("v1".to_string()),
+    //             HeaderItem::Alias(
+    //                 AliasName("a".to_string()),
+    //                 LabelExpression::Or(
+    //                     Box::new(LabelExpression::And(
+    //                         Box::new(LabelExpression::Integer(0)),
+    //                         Box::new(LabelExpression::Integer(1)),
+    //                     )),
+    //                     Box::new(LabelExpression::Integer(2)),
+    //                 ),
+    //             ),
+    //         ],
+    //     );
+
+    //     assert_header(
+    //         "Alias: @a (0 | 1) & 2",
+    //         &[
+    //             HeaderItem::Version("v1".to_string()),
+    //             HeaderItem::Alias(
+    //                 AliasName("a".to_string()),
+    //                 Label,
+    //             ),
+    //         ],
+    //     );
+    // }
+    // #[test]
+    // fn multiple_headers() {}
+}

--- a/hoars/src/input.rs
+++ b/hoars/src/input.rs
@@ -17,7 +17,7 @@ pub fn from_hoa(value: &str) -> Result<HoaAutomaton, FromHoaError> {
             )
         })
         .map_err(FromHoaError::LexerError)?;
-    tracing::debug!("Tokenization took {}ms", start.elapsed().as_millis());
+    tracing::info!("Tokenization took {}µs", start.elapsed().as_micros());
 
     let length = input.chars().count();
     let start = std::time::Instant::now();
@@ -30,6 +30,6 @@ pub fn from_hoa(value: &str) -> Result<HoaAutomaton, FromHoaError> {
             )
         })
         .map_err(FromHoaError::ParserError);
-    tracing::debug!("Actual parsing took {}ms", start.elapsed().as_millis());
+    tracing::info!("Actual parsing took {}µs", start.elapsed().as_micros());
     out
 }

--- a/hoars/src/input.rs
+++ b/hoars/src/input.rs
@@ -1,0 +1,35 @@
+use chumsky::{Parser, Stream};
+
+use crate::{build_error_report, lexer, FromHoaError, HoaAutomaton};
+
+pub fn from_hoa(value: &str) -> Result<HoaAutomaton, FromHoaError> {
+    if value.contains("--ABORT--") {
+        return Err(FromHoaError::Abort);
+    }
+    let input = value;
+    let start = std::time::Instant::now();
+    let tokens = lexer::tokenizer()
+        .parse(input)
+        .map_err(|error_list| {
+            build_error_report(
+                input,
+                error_list.into_iter().map(|err| err.map(|c| c.to_string())),
+            )
+        })
+        .map_err(FromHoaError::LexerError)?;
+    tracing::debug!("Tokenization took {}ms", start.elapsed().as_millis());
+
+    let length = input.chars().count();
+    let start = std::time::Instant::now();
+    let out = HoaAutomaton::parser()
+        .parse(Stream::from_iter(length..length + 1, tokens.into_iter()))
+        .map_err(|error_list| {
+            build_error_report(
+                input,
+                error_list.into_iter().map(|err| err.map(|c| c.to_string())),
+            )
+        })
+        .map_err(FromHoaError::ParserError);
+    tracing::debug!("Actual parsing took {}ms", start.elapsed().as_millis());
+    out
+}

--- a/hoars/src/interpretation.rs
+++ b/hoars/src/interpretation.rs
@@ -1,0 +1,157 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{Id, LabelExpression};
+
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+enum Val {
+    True,
+    False,
+    Undecided,
+}
+
+impl std::ops::BitOr for Val {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Val::True, _) | (_, Val::True) => Val::True,
+            (Val::False, Val::False) => Val::False,
+            _ => Val::Undecided,
+        }
+    }
+}
+
+impl std::ops::BitAnd for Val {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Val::False, _) | (_, Val::False) => Val::False,
+            (Val::True, Val::True) => Val::True,
+            _ => Val::Undecided,
+        }
+    }
+}
+
+impl std::ops::Not for Val {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Val::True => Val::False,
+            Val::False => Val::True,
+            Val::Undecided => Val::Undecided,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct Interpretation {
+    default: Val,
+    map: HashMap<Id, Val>,
+}
+
+impl Interpretation {
+    pub(crate) fn top() -> Self {
+        Interpretation {
+            default: Val::True,
+            pos: HashSet::new(),
+            neg: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn bot() -> Self {
+        Interpretation {
+            default: Val::False,
+            pos: HashSet::new(),
+            neg: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn just(id: Id) -> Self {
+        Interpretation {
+            default: Val::Undecided,
+            pos: vec![id].into_iter().collect(),
+            neg: HashSet::new(),
+        }
+    }
+}
+
+impl std::ops::BitOr for Interpretation {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Interpretation {
+            pos: self.pos.intersection(&rhs.pos).cloned().collect(),
+            neg: self.neg.union(&rhs.neg).cloned().collect(),
+            default: self.default | rhs.default,
+        }
+    }
+}
+
+impl std::ops::BitAnd for Interpretation {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Interpretation {
+            pos: self.pos.union(&rhs.pos).cloned().collect(),
+            neg: self.neg.intersection(&rhs.neg).cloned().collect(),
+            default: self.default & rhs.default,
+        }
+    }
+}
+
+impl std::ops::Not for Interpretation {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Interpretation {
+            pos: self.neg,
+            neg: self.pos,
+            default: !self.default,
+        }
+    }
+}
+
+impl From<&LabelExpression> for Interpretation {
+    fn from(expression: &LabelExpression) -> Self {
+        match expression {
+            LabelExpression::Boolean(b) => {
+                if *b {
+                    Interpretation::top()
+                } else {
+                    Interpretation::bot()
+                }
+            }
+            LabelExpression::Integer(n) => Interpretation::just(*n),
+            LabelExpression::Alias(_) => unimplemented!(),
+            LabelExpression::Not(subexpr) => !Interpretation::from(subexpr.as_ref()),
+            LabelExpression::And(l, r) => {
+                Interpretation::from(l.as_ref()) & Interpretation::from(r.as_ref())
+            }
+            LabelExpression::Or(l, r) => {
+                Interpretation::from(l.as_ref()) | Interpretation::from(r.as_ref())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::LabelExpression;
+
+    use super::Interpretation;
+
+    #[test]
+    fn label_expr_to_interpretation() {
+        let expr = LabelExpression::And(
+            Box::new(LabelExpression::Or(
+                Box::new(LabelExpression::Integer(1)),
+                Box::new(LabelExpression::Boolean(false)),
+            )),
+            Box::new(LabelExpression::Integer(2)),
+        );
+        let interpretation = Interpretation::from(&expr);
+        println!("{:?}", interpretation);
+    }
+}

--- a/hoars/src/lexer.rs
+++ b/hoars/src/lexer.rs
@@ -1,0 +1,93 @@
+use chumsky::prelude::*;
+
+pub type Span = std::ops::Range<usize>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Token {
+    Bool(bool),
+    Int(String),
+    Text(String),
+    Identifier(String),
+    Alias(String),
+    Header(String),
+    Op(char),
+    Paren(char),
+    BodyStart,
+    BodyEnd,
+    Abort,
+    Fin,
+    Inf,
+}
+
+impl std::fmt::Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::Bool(b) => write!(f, "{}", b),
+            Token::Int(n) => write!(f, "{}", n),
+            Token::Text(txt) => write!(f, "{}", txt),
+            Token::Identifier(id) => write!(f, "{}", id),
+            Token::Alias(alias) => write!(f, "@{}", alias),
+            Token::Header(hdr) => write!(f, "{}:", hdr),
+            Token::Op(o) => write!(f, "{}", o),
+            Token::Paren(c) => write!(f, "{}", c),
+            Token::Fin => write!(f, "Fin"),
+            Token::Inf => write!(f, "Inf"),
+            Token::BodyEnd => write!(f, "--END--"),
+            Token::BodyStart => write!(f, "--BODY--"),
+            Token::Abort => write!(f, "--ABORT--"),
+        }
+    }
+}
+
+pub fn tokenizer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
+    let int = text::int(10).map(Token::Int);
+
+    let str_ = just('"')
+        .ignore_then(filter(|c| *c != '"').repeated())
+        .then_ignore(just('"'))
+        .collect::<String>()
+        .map(Token::Text);
+
+    let op = one_of("!|&").map(Token::Op);
+
+    let paren = one_of(r#"(){}[]"#).map(Token::Paren);
+
+    let raw_ident = filter(|c: &char| c.is_ascii_alphabetic() || *c == '_')
+        .chain(filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_' || *c == '-').repeated())
+        .collect::<String>();
+
+    let ident = raw_ident.map(|ident: String| match ident.as_str() {
+        "Fin" => Token::Fin,
+        "Inf" => Token::Inf,
+        _ => Token::Identifier(ident),
+    });
+
+    let alias = just('@').ignore_then(raw_ident).map(Token::Alias);
+
+    let header = ident
+        .then_ignore(just(':'))
+        .map(|header_name| Token::Header(header_name.to_string()));
+
+    let body = just("--BODY--").to(Token::BodyStart);
+    let end = just("--END--").to(Token::BodyEnd);
+    let abort = just("--ABORT--").to(Token::BodyEnd);
+
+    let token = int
+        .or(abort)
+        .or(end)
+        .or(body)
+        .or(header)
+        .or(str_)
+        .or(op)
+        .or(paren)
+        .or(alias)
+        .or(ident);
+
+    let comment = just("/*").then(take_until(just("*/"))).padded();
+
+    token
+        .map_with_span(|tok, span| (tok, span))
+        .padded_by(comment.repeated())
+        .padded()
+        .repeated()
+}

--- a/hoars/src/lib.rs
+++ b/hoars/src/lib.rs
@@ -1,0 +1,528 @@
+//! This crate provides a parser for the HOA format.
+// #![warn(missing_docs)]
+mod body;
+mod format;
+mod header;
+pub mod input;
+mod lexer;
+pub mod output;
+mod value;
+
+use biodivine_lib_bdd::{Bdd, BddVariable, BddVariableSet};
+use std::fmt::Display;
+
+pub type LabelExpression = Bdd;
+
+pub const MAX_APS: usize = 8;
+
+fn build_bdd_vars(alphabet: &BddVariableSet) -> [BddVariable; MAX_APS] {
+    let x = alphabet.variables();
+    [x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]]
+}
+
+lazy_static::lazy_static! {
+    pub static ref ALPHABET: BddVariableSet = BddVariableSet::new_anonymous(8);
+    pub static ref VARS: [BddVariable; MAX_APS] = build_bdd_vars(&ALPHABET);
+}
+
+pub fn first_automaton_split_position(input: &str) -> Option<usize> {
+    const ENDLEN: usize = "--END--".len();
+
+    'outer: loop {
+        if let Some(end) = input.find("--END--") {
+            if let Some(abort) = input.find("--ABORT--") {
+                if abort < end {
+                    continue 'outer;
+                }
+            }
+            return Some(end + ENDLEN);
+        } else {
+            return None;
+        }
+    }
+}
+
+pub fn parse_hoa_automata(input: &str) -> Vec<HoaAutomaton> {
+    let mut out = Vec::new();
+    for hoa_aut in input.split_inclusive("--END--") {
+        if !hoa_aut.contains("--BODY--") {
+            continue;
+        }
+        match hoa_aut.try_into() {
+            Ok(aut) => out.push(aut),
+            Err(e) => println!("Error when parsing automaton: {}", e),
+        }
+    }
+    out
+}
+
+use ariadne::{Color, Fmt, ReportKind, Source};
+
+#[allow(unused_imports)]
+use chumsky::prelude::*;
+pub use format::*;
+
+use chumsky::{prelude::Simple, Parser};
+pub use format::{
+    AcceptanceCondition, AcceptanceInfo, AcceptanceName, AcceptanceSignature, AliasName, Property,
+};
+
+pub use body::{Body, Edge, Label, State};
+pub use header::{Header, HeaderItem};
+
+use itertools::Itertools;
+use lexer::Token;
+
+/// The type of identifier used for states.
+pub type Id = u32;
+
+/// Represents the different types of error that can be encountered when parsing a [`HoaAutomaton`].
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FromHoaError {
+    /// The version string does not match, we only support v1.
+    UnsupportedVersion(String),
+    /// Encapsulates that an unsupported acceptance condition was used.
+    UnsupportedAcceptanceCondition,
+    /// An error occurred when parsing the acceptance condition.
+    ParseAcceptanceCondition(String),
+    /// There was an error in the body.
+    UnsupportedBody,
+    /// Lexer encountered an error, contains detailed report.
+    LexerError(String),
+    /// Parser encountered an error, contains detailed report.
+    ParserError(String),
+    /// Abort token was encountered.
+    Abort,
+}
+
+impl Display for FromHoaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FromHoaError::UnsupportedVersion(version) => {
+                write!(f, "Unsupported HOA version ({})", version)
+            }
+            FromHoaError::UnsupportedAcceptanceCondition => {
+                write!(f, "Unsupported acceptance condition")
+            }
+            FromHoaError::UnsupportedBody => write!(f, "Unsupported body"),
+            FromHoaError::ParseAcceptanceCondition(message) => {
+                write!(f, "Could not parse acceptance condition: {}", message)
+            }
+            FromHoaError::Abort => write!(f, "Abort token encountered"),
+            FromHoaError::LexerError(rep) => write!(f, "Lexer error: {}", rep),
+            FromHoaError::ParserError(rep) => write!(f, "Parser error: {}", rep),
+        }
+    }
+}
+
+/// Represents a parsed HOA automaton. It consists of a the version string,
+/// a [`Header`] and a [`Body`].
+/// The header contains all the information about the automaton (e.g. the number of states, the
+/// acceptance condition, aliases etc.) and the body contains the actual transitions.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct HoaAutomaton {
+    header: Header,
+    body: Body,
+}
+
+/// Represents an acceptance condition as it is encoded in a HOA automaton.
+pub type HoaAcceptance = (usize, AcceptanceCondition);
+
+/// Stores information on aliases, it holds a vector of pairs of alias
+/// names and label expression. This can be used to unalias an automaton.
+pub type Aliases = Vec<(AliasName, LabelExpression)>;
+
+impl HoaAutomaton {
+    /// Adds the given state.
+    pub fn add_state(&mut self, state: State) {
+        self.body.push(state);
+    }
+
+    /// Returns the version of the HOA file.
+    pub fn version(&self) -> String {
+        self.header.get_version().expect("Version must be set!")
+    }
+
+    /// Returns the header of the HOA file.
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    pub fn header_mut(&mut self) -> &mut Header {
+        &mut self.header
+    }
+
+    /// Returns the body of the HOA file.
+    pub fn body(&self) -> &Body {
+        &self.body
+    }
+
+    pub fn body_mut(&mut self) -> &mut Body {
+        &mut self.body
+    }
+
+    fn from_parsed((header, body): (Header, Body)) -> Self {
+        Self::from_parts(header, body)
+    }
+
+    /// Parses a HOA automaton from a string.
+    pub fn parser() -> impl Parser<Token, Self, Error = Simple<Token>> {
+        Header::parser()
+            .then(Body::parser())
+            .then_ignore(end())
+            .map(HoaAutomaton::from_parsed)
+    }
+
+    /// Creates a new HOA automaton from the given version, header and
+    /// body. This function will also unalias the automaton.
+    pub fn from_parts(header: Header, body: Body) -> Self {
+        let mut out = Self { header, body };
+        out.body.sort_by(|x, y| x.0.cmp(&y.0));
+        out
+    }
+
+    /// Verifies that the automaton is well-formed. This means that
+    /// - the number of states is set correctly
+    /// - all states are defined exactly once
+    pub fn verify(&self) -> Result<(), String> {
+        let mut errors = Vec::new();
+        let mut states = Vec::new();
+        for state in self.body().iter() {
+            if states.contains(&state.id()) {
+                errors.push(format!("State {} is defined more than once!", state.id()));
+            }
+            states.push(state.id());
+        }
+        if let Some(num_states) = self.num_states() {
+            if states.len() != num_states {
+                errors.push(format!(
+                    "The number of states is set to {} but there are {} states!",
+                    num_states,
+                    states.len()
+                ));
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("\n"))
+        }
+    }
+
+    /// Returns the number of states in the automaton.
+    pub fn num_states(&self) -> Option<usize> {
+        debug_assert!(
+            self.header()
+                .iter()
+                .filter(|item| matches!(item, HeaderItem::States(_)))
+                .count()
+                == 1,
+            "The number of states must be set exactly once!"
+        );
+        self.header().iter().find_map(|item| match item {
+            HeaderItem::States(id) => Some(*id as usize),
+            _ => None,
+        })
+    }
+
+    /// Returns the number of edges in the automaton.
+    pub fn start(&self) -> Vec<&StateConjunction> {
+        debug_assert!(
+            self.header()
+                .iter()
+                .filter(|item| matches!(item, HeaderItem::Start(_)))
+                .count()
+                >= 1,
+            "At least one initial state conjunction has to be present!"
+        );
+        self.header()
+            .iter()
+            .filter_map(|item| match item {
+                HeaderItem::Start(start) => Some(start),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns the set of all atomic propositions in the automaton.
+    pub fn aps(&self) -> &Vec<String> {
+        let aps = self
+            .header()
+            .iter()
+            .filter_map(|item| match item {
+                HeaderItem::AP(ap) => Some(ap),
+                _ => None,
+            })
+            .collect_vec();
+        debug_assert!(aps.len() == 1, "There must be exactly one AP header!");
+        aps.first().unwrap()
+    }
+
+    /// Counts the number of atomic propositions in the automaton.
+    pub fn num_aps(&self) -> usize {
+        self.aps().len()
+    }
+
+    /// Returns the acceptance condition of the automaton.
+    pub fn acceptance(&self) -> HoaAcceptance {
+        debug_assert!(
+            self.header()
+                .iter()
+                .filter(|item| matches!(item, HeaderItem::Acceptance(..)))
+                .count()
+                == 1,
+            "There must be exactly one Acceptance header!"
+        );
+        self.header()
+            .iter()
+            .find_map(|item| match item {
+                HeaderItem::Acceptance(acceptance_sets, condition) => {
+                    Some((*acceptance_sets as usize, condition.clone()))
+                }
+                _ => None,
+            })
+            .expect("Acceptance header is missing!")
+    }
+
+    /// Returns the aliases of the automaton.
+    pub fn aliases(&self) -> Vec<(AliasName, LabelExpression)> {
+        self.header()
+            .iter()
+            .filter_map(|item| match item {
+                HeaderItem::Alias(name, expr) => Some((name.clone(), expr.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns the acceptance name of the automaton.
+    pub fn acceptance_name(&self) -> Option<(&AcceptanceName, &Vec<AcceptanceInfo>)> {
+        debug_assert!(
+            self.header()
+                .iter()
+                .filter(|item| matches!(item, HeaderItem::AcceptanceName(..)))
+                .count()
+                == 1,
+            "There must be exactly one AcceptanceName header!"
+        );
+        self.header().iter().find_map(|item| match item {
+            HeaderItem::AcceptanceName(name, info) => Some((name, info)),
+            _ => None,
+        })
+    }
+
+    /// Adds a header item to the automaton.
+    pub fn add_header_item(&mut self, item: HeaderItem) {
+        self.header.push(item);
+    }
+}
+
+impl Default for HoaAutomaton {
+    fn default() -> Self {
+        HoaAutomaton::from_parts(vec![HeaderItem::Version("v1".into())].into(), vec![].into())
+    }
+}
+
+// fn reporter<D: std::fmt::Display>(input: &str) -> impl Fn(D)
+
+impl TryFrom<&str> for HoaAutomaton {
+    type Error = FromHoaError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        input::from_hoa(value)
+    }
+}
+
+fn build_error_report<I: Iterator<Item = Simple<String>>>(input: &str, errs: I) -> String {
+    errs.into_iter()
+        .map(|e| {
+            let report = ariadne::Report::build(ReportKind::Error, (), e.span().start);
+
+            let report = match e.reason() {
+                chumsky::error::SimpleReason::Unexpected => report
+                    .with_message(format!(
+                        "{}, expected {}",
+                        if e.found().is_some() {
+                            "Unexpected token in input"
+                        } else {
+                            "Unexpected end of input"
+                        },
+                        if e.expected().len() == 0 {
+                            "something else".to_string()
+                        } else {
+                            e.expected()
+                                .map(|expected| match expected {
+                                    Some(expected) => expected.to_string(),
+                                    None => "end of input".to_string(),
+                                })
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        }
+                    ))
+                    .with_label(
+                        ariadne::Label::new(e.span())
+                            .with_message(format!(
+                                "Unexpected token {}",
+                                e.found()
+                                    .unwrap_or(&"end of file".to_string())
+                                    .fg(Color::Red)
+                            ))
+                            .with_color(Color::Red),
+                    ),
+                chumsky::error::SimpleReason::Unclosed { span, delimiter } => report
+                    .with_message(format!(
+                        "Unclosed delimiter {}",
+                        delimiter.fg(Color::Yellow)
+                    ))
+                    .with_label(
+                        ariadne::Label::new(span.clone())
+                            .with_message(format!(
+                                "Unclosed delimiter {}",
+                                delimiter.fg(Color::Yellow)
+                            ))
+                            .with_color(Color::Yellow),
+                    )
+                    .with_label(
+                        ariadne::Label::new(e.span())
+                            .with_message(format!(
+                                "Must be closed before this {}",
+                                e.found()
+                                    .unwrap_or(&"end of file".to_string())
+                                    .fg(Color::Red)
+                            ))
+                            .with_color(Color::Red),
+                    ),
+                chumsky::error::SimpleReason::Custom(msg) => report.with_message(msg).with_label(
+                    ariadne::Label::new(e.span())
+                        .with_message(format!("{}", msg.fg(Color::Red)))
+                        .with_color(Color::Red),
+                ),
+            };
+
+            let mut report_output = Vec::new();
+            report
+                .finish()
+                .write(Source::from(input), &mut report_output)
+                .unwrap();
+
+            std::str::from_utf8(&report_output)
+                .unwrap_or("Could not parse error report")
+                .to_string()
+        })
+        .join("\n")
+}
+
+#[cfg(test)]
+fn print_error_report<I: Iterator<Item = Simple<String>>>(input: &str, errs: I) {
+    eprintln!("{}", build_error_report(input, errs))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        body::{Edge, State},
+        header::Header,
+        AcceptanceAtom, AcceptanceCondition, AcceptanceName, AcceptanceSignature, Body, HeaderItem,
+        HoaAutomaton, Label, StateConjunction, ALPHABET, VARS,
+    };
+
+    #[test]
+    fn first_automaton_split_and_abort() {
+        let contents = "HOA: v1\n--END--\nHOA: v1\n--ABORT--\nHOA: v1\n--END--\n";
+
+        let first = super::first_automaton_split_position(contents);
+        assert_eq!(first, Some(15));
+    }
+
+    #[test]
+    fn real_test_1() {
+        let contents = r#"HOA: v1
+             AP: 1 "a"
+             States: 3
+             Start: 0
+             acc-name: Buchi
+             Acceptance: 1 Inf(0)
+             --BODY--
+             State: 0 {0}
+              [0] 1
+              [!0]  2
+             State: 1  /* former state 0 */
+              [0] 1
+              [!0] 2
+             State: 2  /* former state 1 */
+              [0] 1
+              [!0] 2
+             --END--
+             "#;
+        let hoa_aut = HoaAutomaton::try_from(contents);
+
+        if let Err(err) = hoa_aut {
+            println!("Encountered paring error\n{}", err);
+            return;
+        }
+
+        let header = Header::from_vec(vec![
+            HeaderItem::Version("v1".to_string()),
+            HeaderItem::AP(vec!["a".to_string()]),
+            HeaderItem::States(3),
+            HeaderItem::Start(StateConjunction(vec![0])),
+            HeaderItem::AcceptanceName(AcceptanceName::Buchi, vec![]),
+            HeaderItem::Acceptance(1, AcceptanceCondition::Inf(AcceptanceAtom::Positive(0))),
+        ]);
+        let q0 = State::from_parts(
+            0,
+            None,
+            vec![
+                Edge::from_parts(
+                    Label(ALPHABET.mk_var(VARS[0])),
+                    StateConjunction(vec![1]),
+                    AcceptanceSignature(vec![0]),
+                ),
+                Edge::from_parts(
+                    Label(ALPHABET.mk_var(VARS[0]).not()),
+                    StateConjunction(vec![2]),
+                    AcceptanceSignature(vec![0]),
+                ),
+            ],
+        );
+        let q1 = State::from_parts(
+            1,
+            None,
+            vec![
+                Edge::from_parts(
+                    Label(ALPHABET.mk_var(VARS[0])),
+                    StateConjunction(vec![1]),
+                    AcceptanceSignature(vec![]),
+                ),
+                Edge::from_parts(
+                    Label(ALPHABET.mk_var(VARS[0]).not()),
+                    StateConjunction(vec![2]),
+                    AcceptanceSignature(vec![]),
+                ),
+            ],
+        );
+        let q2 = State::from_parts(
+            2,
+            None,
+            vec![
+                Edge::from_parts(
+                    Label(ALPHABET.mk_var(VARS[0])),
+                    StateConjunction(vec![1]),
+                    AcceptanceSignature(vec![]),
+                ),
+                Edge::from_parts(
+                    Label(ALPHABET.mk_var(VARS[0]).not()),
+                    StateConjunction(vec![2]),
+                    AcceptanceSignature(vec![]),
+                ),
+            ],
+        );
+        assert_eq!(
+            hoa_aut,
+            Ok(HoaAutomaton::from_parts(
+                header,
+                Body::from(vec![q0, q1, q2])
+            ))
+        )
+    }
+}

--- a/hoars/src/output.rs
+++ b/hoars/src/output.rs
@@ -1,0 +1,183 @@
+use std::fmt::Display;
+
+use itertools::Itertools;
+
+use crate::{
+    AcceptanceAtom, AcceptanceCondition, AcceptanceInfo, AcceptanceName, AcceptanceSignature,
+    AliasName, Edge, HeaderItem, HoaAutomaton, HoaBool, Label, Property, State, StateConjunction,
+};
+
+pub fn to_hoa(aut: &HoaAutomaton) -> String {
+    aut.header()
+        .into_iter()
+        .map(|header_item| header_item.to_string())
+        .chain(std::iter::once("--BODY--".to_string()))
+        .chain(aut.body().into_iter().map(|state| state.to_string()))
+        .chain(std::iter::once("--END--".to_string()))
+        .join("\n")
+}
+
+impl Display for HeaderItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HeaderItem::Version(version) => write!(f, "HOA: {}", version),
+            HeaderItem::States(number) => write!(f, "States: {}", number),
+            HeaderItem::Start(state_conj) => write!(f, "Start: {}", state_conj),
+            HeaderItem::AP(aps) => write!(
+                f,
+                "AP: {} {}",
+                aps.len(),
+                aps.iter().map(|ap| format!("\"{}\"", ap)).join(" ")
+            ),
+            HeaderItem::Alias(alias_name, alias_expression) => {
+                write!(f, "Alias: {} {}", alias_name, alias_expression)
+            }
+            HeaderItem::Acceptance(number_sets, condition) => {
+                write!(f, "Acceptance: {} {}", number_sets, condition)
+            }
+            HeaderItem::AcceptanceName(identifier, vec_info) => {
+                write!(f, "acc-name: {} {}", identifier, vec_info.iter().join(" "))
+            }
+            HeaderItem::Tool(name, options) => {
+                write!(f, "tool: {} {}", name, options.iter().join(" "))
+            }
+            HeaderItem::Name(name) => write!(f, "name: {}", name),
+            HeaderItem::Properties(properties) => {
+                write!(f, "properties: {}", properties.iter().join(" "))
+            }
+        }
+    }
+}
+
+impl Display for AcceptanceInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptanceInfo::Int(integer) => write!(f, "{}", integer),
+            AcceptanceInfo::Identifier(identifier) => write!(f, "{}", identifier),
+        }
+    }
+}
+
+impl Display for Property {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Property::StateLabels => "state-labels",
+                Property::TransLabels => "trans-labels",
+                Property::ImplicitLabels => "implicit-labels",
+                Property::ExplicitLabels => "explicit-labels",
+                Property::StateAcceptance => "state-acc",
+                Property::TransitionAcceptance => "trans-acc",
+                Property::UniversalBranching => "univ-branch",
+                Property::NoUniversalBranching => "no-univ-branch",
+                Property::Deterministic => "deterministic",
+                Property::Complete => "complete",
+                Property::Unambiguous => "unabmiguous",
+                Property::StutterInvariant => "stutter-invariant",
+                Property::Weak => "weak",
+                Property::VeryWeak => "very-weak",
+                Property::InherentlyWeak => "inherently-weak",
+                Property::Terminal => "terminal",
+                Property::Tight => "tight",
+                Property::Colored => "colored",
+            }
+        )
+    }
+}
+
+impl Display for AcceptanceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                AcceptanceName::Buchi => "Buchi",
+                AcceptanceName::GeneralizedBuchi => "generalized-Buchi",
+                AcceptanceName::CoBuchi => "co-Buchi",
+                AcceptanceName::GeneralizedCoBuchi => "generalized-co-Buchi",
+                AcceptanceName::Streett => "Streett",
+                AcceptanceName::Rabin => "Rabin",
+                AcceptanceName::GeneralizedRabin => "generalized-Rabin",
+                AcceptanceName::Parity => "parity",
+                AcceptanceName::All => "all",
+                AcceptanceName::None => "none",
+            }
+        )
+    }
+}
+
+impl Display for AcceptanceAtom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptanceAtom::Positive(id) => write!(f, "{}", id),
+            AcceptanceAtom::Negative(id) => write!(f, "!{}", id),
+        }
+    }
+}
+
+impl Display for HoaBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", if self.0 { "t" } else { "f" })
+    }
+}
+
+impl Display for AcceptanceCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptanceCondition::Fin(id) => write!(f, "Fin({})", id),
+            AcceptanceCondition::Inf(id) => write!(f, "Inf({})", id),
+            AcceptanceCondition::And(left, right) => write!(f, "({} & {})", left, right),
+            AcceptanceCondition::Or(left, right) => write!(f, "({} | {})", left, right),
+            AcceptanceCondition::Boolean(val) => write!(f, "{}", val),
+        }
+    }
+}
+
+impl Display for AliasName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "@{}", self.0)
+    }
+}
+
+impl Display for StateConjunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.iter().map(|s| s.to_string()).join(" & "))
+    }
+}
+
+impl Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}]", self.0)
+    }
+}
+
+impl Display for AcceptanceSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_empty() {
+            return Ok(());
+        }
+        write!(f, "{{{}}}", self.0.iter().join(" "))
+    }
+}
+
+impl Display for Edge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {} {}", self.0, self.1, self.2)
+    }
+}
+
+impl Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(acc) = &self.1 {
+            writeln!(f, "State: {} \"{}\"", self.0, acc)?;
+        } else {
+            writeln!(f, "State: {}", self.0)?;
+        }
+        for edge in &self.2 {
+            writeln!(f, "{}", edge)?;
+        }
+        Ok(())
+    }
+}

--- a/hoars/src/value.rs
+++ b/hoars/src/value.rs
@@ -1,0 +1,174 @@
+use biodivine_lib_bdd::Bdd;
+use chumsky::{prelude::*, select};
+
+use crate::{
+    AcceptanceAtom, AcceptanceCondition, AcceptanceInfo, AcceptanceSignature, HoaBool, Id,
+    StateConjunction, Token, MAX_APS,
+};
+
+#[allow(unused)]
+pub fn header() -> impl Parser<Token, String, Error = Simple<Token>> + Clone {
+    select! {
+        Token::Header(hdr) => hdr,
+    }
+}
+
+pub fn boolean() -> impl Parser<Token, bool, Error = Simple<Token>> + Clone {
+    select! {
+        Token::Identifier(id) if id == *"t" => true,
+        Token::Identifier(id) if id == *"f" => false,
+    }
+}
+
+pub fn integer() -> impl Parser<Token, Id, Error = Simple<Token>> + Clone {
+    select! {
+        Token::Int(n) => n.parse().unwrap(),
+    }
+}
+
+pub fn text() -> impl Parser<Token, String, Error = Simple<Token>> + Clone {
+    select! {
+        Token::Text(txt) => txt,
+    }
+}
+
+pub fn identifier() -> impl Parser<Token, String, Error = Simple<Token>> + Clone {
+    select! { Token::Identifier(ident) => ident }
+}
+
+pub fn alias_name() -> impl Parser<Token, String, Error = Simple<Token>> + Clone {
+    select! { Token::Alias(aname) => aname }
+}
+
+pub fn state_conjunction() -> impl Parser<Token, StateConjunction, Error = Simple<Token>> {
+    integer()
+        .separated_by(just(Token::Op('&')))
+        .at_least(1)
+        .map(StateConjunction)
+}
+
+pub fn acceptance_signature() -> impl Parser<Token, AcceptanceSignature, Error = Simple<Token>> {
+    integer()
+        .repeated()
+        .delimited_by(just(Token::Paren('{')), just(Token::Paren('}')))
+        .map(AcceptanceSignature)
+}
+
+pub fn acceptance_info() -> impl Parser<Token, AcceptanceInfo, Error = Simple<Token>> {
+    select! {
+        Token::Identifier(ident) => AcceptanceInfo::Identifier(ident),
+        Token::Int(n) => AcceptanceInfo::Int(n.parse().unwrap())
+    }
+}
+
+pub fn label_expression() -> impl Parser<Token, Bdd, Error = Simple<Token>> {
+    recursive(|label_expression| {
+        let value = boolean()
+            .map(|b| {
+                if b {
+                    crate::ALPHABET.mk_true()
+                } else {
+                    crate::ALPHABET.mk_false()
+                }
+            })
+            .or(integer().map(|i| {
+                assert!(
+                    (i as usize) < MAX_APS,
+                    "invalid AP, {} is above limit {}",
+                    i,
+                    MAX_APS
+                );
+                crate::ALPHABET.mk_var(crate::VARS[i as usize])
+            }));
+        // .or(alias_name().map(|aname| LabelExpression::Alias(AliasName(aname))));
+
+        let atom = value
+            .or(label_expression.delimited_by(just(Token::Paren('(')), just(Token::Paren(')'))));
+
+        let unary = just(Token::Op('!'))
+            .or_not()
+            .then(atom)
+            .map(
+                |(negated, expr)| {
+                    if negated.is_some() {
+                        expr.not()
+                    } else {
+                        expr
+                    }
+                },
+            );
+
+        let f_conjunction = |l: Bdd, r: &Bdd| l.and(r);
+
+        let conjunction = unary
+            .clone()
+            .then(
+                just(Token::Op('&'))
+                    .to(f_conjunction)
+                    .then(unary)
+                    .repeated(),
+            )
+            .foldl(|lhs, (f, rhs)| f(lhs, &rhs));
+
+        let f_disjunction = |l: Bdd, r: &Bdd| l.or(r);
+
+        conjunction
+            .clone()
+            .then(
+                just(Token::Op('|'))
+                    .to(f_disjunction)
+                    .then(conjunction)
+                    .repeated(),
+            )
+            .foldl(|lhs, (f, rhs)| f(lhs, &rhs))
+    })
+}
+
+pub fn acceptance_condition() -> impl Parser<Token, AcceptanceCondition, Error = Simple<Token>> {
+    recursive(|acceptance_condition| {
+        let atom_value = just(Token::Op('!'))
+            .or_not()
+            .then(integer())
+            .map(|(negated, integer)| {
+                if negated.is_none() {
+                    AcceptanceAtom::Positive(integer)
+                } else {
+                    AcceptanceAtom::Negative(integer)
+                }
+            });
+
+        let fin_inf_atom = just(Token::Fin)
+            .to(AcceptanceCondition::Fin as fn(_) -> _)
+            .or(just(Token::Inf).to(AcceptanceCondition::Inf as fn(_) -> _))
+            .then(atom_value.delimited_by(just(Token::Paren('(')), just(Token::Paren(')'))))
+            .map(|(f, atom)| f(atom));
+
+        let atom =
+            boolean()
+                .map(HoaBool)
+                .map(AcceptanceCondition::Boolean)
+                .or(fin_inf_atom)
+                .or(acceptance_condition
+                    .delimited_by(just(Token::Paren('(')), just(Token::Paren(')'))));
+
+        let conjunction = atom
+            .clone()
+            .then(
+                just(Token::Op('&'))
+                    .to(AcceptanceCondition::And)
+                    .then(atom)
+                    .repeated(),
+            )
+            .foldl(|lhs, (f, rhs)| f(Box::new(lhs), Box::new(rhs)));
+
+        conjunction
+            .clone()
+            .then(
+                just(Token::Op('|'))
+                    .to(AcceptanceCondition::Or)
+                    .then(conjunction)
+                    .repeated(),
+            )
+            .foldl(|lhs, (f, rhs)| f(Box::new(lhs), Box::new(rhs)))
+    })
+}

--- a/src/automaton/dpa.rs
+++ b/src/automaton/dpa.rs
@@ -75,6 +75,13 @@ where
             .and_then(|r| r.last_transition_color().cloned())
     }
 
+    /// Computes the least and greatest edge color that appears on any edge of the automaton.
+    /// If there are no edges, `(usize::MAX, 0)` is returned.
+    pub fn low_and_high_priority(&self) -> (usize, usize) {
+        self.edge_colors_unique()
+            .fold((usize::MAX, 0), |(low, high), c| (low.min(c), high.max(c)))
+    }
+
     /// Transforms the given [`FiniteWord`] into a [`EdgeColor`]. This simply calls [`Self::try_last_edge_color`]
     /// and subsequently unwraps the result.
     pub fn last_edge_color<W: FiniteWord<SymbolOf<Self>>>(&self, input: W) -> EdgeColor<Self> {

--- a/src/automaton/omega.rs
+++ b/src/automaton/omega.rs
@@ -50,7 +50,7 @@ impl From<&hoars::AcceptanceSignature> for AcceptanceMask {
 
 #[derive(Debug, Clone, Eq, Copy, PartialEq, Ord, PartialOrd)]
 pub enum OmegaAcceptanceCondition {
-    Parity,
+    Parity(usize, usize),
     Buchi,
     Rabin,
     Streett,
@@ -63,7 +63,7 @@ pub enum OmegaAcceptanceCondition {
 impl OmegaAcceptanceCondition {
     pub fn satisfied(&self, infset: &Set<AcceptanceMask>) -> bool {
         match self {
-            OmegaAcceptanceCondition::Parity => infset
+            OmegaAcceptanceCondition::Parity(_low, _high) => infset
                 .iter()
                 .map(|x| x.as_priority())
                 .min()

--- a/src/hoa.rs
+++ b/src/hoa.rs
@@ -73,6 +73,25 @@ impl HoaAlphabet {
         self.apnames.len()
     }
 
+    /// Attempts to build an instance of `Self` from the given pointer to a [`CharAlphabet`]. This
+    /// only works (for the moment) if the number of symbols in the given alphabet is an exact
+    /// power of two.
+    pub fn try_from_char_alphabet(value: &CharAlphabet) -> Result<Self, String> {
+        let alphabet_size = value.size();
+        if alphabet_size != alphabet_size.next_power_of_two() || alphabet_size == 0 {
+            return Err(format!(
+                "Alphabet size is not a power of two: {alphabet_size}"
+            ));
+        }
+
+        let aps = alphabet_size.ilog2() as u8;
+        assert!(aps > 0, "We do not want this edge case");
+
+        Ok(Self::from_apnames(
+            (0u8..aps).map(|i| ((b'a' + i) as char).to_string()),
+        ))
+    }
+
     pub fn from_apnames<I: IntoIterator<Item = String>>(apnames: I) -> Self {
         let apnames: Vec<_> = apnames.into_iter().collect();
         assert!(apnames.len() < MAX_APS);

--- a/src/hoa.rs
+++ b/src/hoa.rs
@@ -6,6 +6,9 @@ use crate::{prelude::*, Map};
 use biodivine_lib_bdd::{Bdd, BddSatisfyingValuations, BddValuation, BddVariable};
 use hoars::{HoaAutomaton, ALPHABET, MAX_APS, VARS};
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct HoaStream(pub(crate) String);
+
 /// A propositional alphabet, where a symbol is a valuation of all propositional variables.
 ///
 /// # Example

--- a/src/hoa.rs
+++ b/src/hoa.rs
@@ -7,7 +7,7 @@ use biodivine_lib_bdd::{Bdd, BddSatisfyingValuations, BddValuation, BddVariable}
 use hoars::{HoaAutomaton, ALPHABET, MAX_APS, VARS};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct HoaStream(pub(crate) String);
+pub struct HoaString(pub(crate) String);
 
 /// A propositional alphabet, where a symbol is a valuation of all propositional variables.
 ///
@@ -28,6 +28,19 @@ pub struct HoaAlphabet {
 }
 
 impl HoaAlphabet {
+    pub fn size(&self) -> usize {
+        2u32.saturating_pow(self.apnames.len() as u32)
+            .try_into()
+            .expect("Cannot fit value into usize")
+    }
+
+    pub fn apnames(&self) -> &[String] {
+        &self.apnames
+    }
+    pub fn apnames_len(&self) -> usize {
+        self.apnames.len()
+    }
+
     pub fn from_hoa_automaton(aut: &HoaAutomaton) -> Self {
         let apnames = aut.aps().clone();
         assert!(apnames.len() < MAX_APS);

--- a/src/hoa/input.rs
+++ b/src/hoa/input.rs
@@ -3,7 +3,15 @@ use std::ops::Deref;
 use crate::{automaton::AcceptanceMask, hoa::HoaExpression, prelude::*};
 use hoars::{HoaAutomaton, MAX_APS};
 
-use super::HoaAlphabet;
+use super::{HoaAlphabet, HoaStream};
+
+/// Tries to `pop` the foremost valid HOA automaton from the given [`HoaStream`].
+/// If no valid automaton is found before the end of the stream is reached, the
+/// function returns `None`.
+pub fn pop_omega_automaton(
+    hoa_stream: HoaStream,
+) -> Option<(OmegaAutomaton<HoaAlphabet>, HoaStream)> {
+}
 
 /// Considers the given HOA string as a single automaton and tries to parse it into an
 /// [`OmegaAutomaton`].
@@ -72,4 +80,30 @@ pub fn hoa_automaton_to_nts(
         .expect("Initial state must be a singleton") as usize;
 
     ts.with_initial(initial)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn hoa_tdba() {
+        let aut_hoa = r#"
+        HOA: v1
+        States: 3
+        Start: 0
+        acc-name: Buchi
+        Acceptance: 1 Inf(0)
+        AP: 1 "a"
+        --BODY--
+        State: 0
+        [0] 1
+        [!0]  2
+        State: 1  /* former state 0 */
+        [0] 1 {0}
+        [!0] 2 {0}
+        State: 2  /* former state 1 */
+        [0] 1
+        [!0] 2
+        --END--
+        "#;
+    }
 }

--- a/src/hoa/input.rs
+++ b/src/hoa/input.rs
@@ -31,7 +31,7 @@ impl<R: BufRead> Iterator for FilterDeterministicHoaAutomatonStream<R> {
             match self.base.next() {
                 None => return None,
                 Some(aut) => {
-                    if let Some(det) = aut.to_deterministic() {
+                    if let Some(det) = aut.into_deterministic() {
                         return Some(det);
                     } else {
                         warn!("Encountered automaton that is not deterministic, skipping...")
@@ -119,7 +119,7 @@ pub fn pop_deterministic_omega_automaton(
 ) -> Option<(DeterministicOmegaAutomaton<HoaAlphabet>, HoaString)> {
     let mut hoa = hoa;
     while let Some((aut, rest)) = pop_omega_automaton(hoa) {
-        if let Some(det) = aut.to_deterministic() {
+        if let Some(det) = aut.into_deterministic() {
             return Some((det, rest));
         }
         trace!("Automaton was not deterministic, skipping");

--- a/src/hoa/output.rs
+++ b/src/hoa/output.rs
@@ -1,25 +1,229 @@
-use hoars::HoaAutomaton;
+use itertools::Itertools;
 
-use crate::{automaton::IntoDPA, prelude::*};
+use crate::prelude::*;
 
 use super::HoaAlphabet;
 
-pub trait ToHoa: TransitionSystem + Pointed {
+use std::fmt::{Result, Write};
+
+pub trait WriteHoa: TransitionSystem + Pointed {
+    fn write_hoa<W: Write>(&self, w: &mut W) -> Result {
+        w.write_str("HOA: v1\n")?;
+
+        self.write_alphabet_description(w)?;
+
+        w.write_fmt(format_args!("States: {}\n", self.size()))?;
+
+        w.write_str("Start: ")?;
+        self.write_state_id(w, self.initial())?;
+        w.write_char('\n')?;
+
+        self.write_acceptance(w)?;
+
+        w.write_str("--BODY--")?;
+
+        for state in self.state_indices() {
+            w.write_str("\nState: ")?;
+            self.write_state_id(w, state)?;
+            for edge in self.edges_from(state).expect("We know this state exists") {
+                w.write_char('\n')?;
+                w.write_char('[')?;
+                self.write_expression(w, edge.expression())?;
+                w.write_char(']')?;
+                w.write_char(' ')?;
+
+                self.write_state_id(w, edge.target())?;
+
+                w.write_char(' ')?;
+                self.write_edge_color(w, edge.color())?;
+            }
+        }
+
+        w.write_str("\n--END--\n")?;
+
+        Ok(())
+    }
+
+    fn write_edge_color<W: std::fmt::Write>(&self, w: &mut W, label: EdgeColor<Self>) -> Result;
+
+    fn write_expression<W: std::fmt::Write>(&self, w: &mut W, expr: &ExpressionOf<Self>) -> Result;
+
+    fn write_state_id<W: std::fmt::Write>(
+        &self,
+        w: &mut W,
+        id: Self::StateIndex,
+    ) -> std::fmt::Result;
+
+    fn write_alphabet_description<W: std::fmt::Write>(&self, w: &mut W) -> Result;
+
+    fn write_acceptance<W: std::fmt::Write>(&self, w: &mut W) -> Result;
+
     fn to_hoa(&self) -> String {
-        hoars::output::to_hoa(&self.to_hoa_automaton())
-    }
-
-    fn to_hoa_automaton(&self) -> HoaAutomaton;
-}
-
-impl<D: TransitionSystem<Alphabet = HoaAlphabet>> ToHoa for IntoDPA<D> {
-    fn to_hoa_automaton(&self) -> HoaAutomaton {
-        let mut aut = HoaAutomaton::default();
-        aut.add_header_item(hoa_alphabet_to_header_item(self.alphabet()));
-        todo!()
+        let mut w = String::new();
+        self.write_hoa(&mut w).unwrap();
+        w
     }
 }
 
-fn hoa_alphabet_to_header_item(_alphabet: &HoaAlphabet) -> hoars::HeaderItem {
-    todo!()
+impl OmegaAcceptanceCondition {
+    pub fn write_hoa<W: Write>(&self, w: &mut W) -> Result {
+        match self {
+            OmegaAcceptanceCondition::Parity(low, high) => {
+                let zero_based_range = high - low + (low % 2);
+                write!(
+                    w,
+                    "acc-name: parity min even {}\nAcceptance: {}\n",
+                    zero_based_range,
+                    build_parity_condition_hoa(*low, *high)
+                )
+            }
+            _ => todo!("Can not yet deal with other acceptance types"),
+        }
+    }
+}
+
+pub trait HoaSuitableAlphabet: Alphabet {
+    fn write_expression<W: std::fmt::Write>(&self, w: &mut W, expr: &Self::Expression) -> Result;
+    fn write_alphabet_description<W: std::fmt::Write>(&self, w: &mut W) -> Result;
+}
+
+impl<A: HoaSuitableAlphabet> WriteHoa for DPA<A> {
+    fn write_edge_color<W: std::fmt::Write>(&self, w: &mut W, label: EdgeColor<Self>) -> Result {
+        write!(w, "{{{}}}", label)
+    }
+
+    fn write_expression<W: std::fmt::Write>(&self, w: &mut W, expr: &ExpressionOf<Self>) -> Result {
+        self.alphabet().write_expression(w, expr)
+    }
+
+    fn write_state_id<W: std::fmt::Write>(
+        &self,
+        w: &mut W,
+        id: Self::StateIndex,
+    ) -> std::fmt::Result {
+        write!(w, "{}", id)
+    }
+
+    fn write_alphabet_description<W: std::fmt::Write>(&self, w: &mut W) -> Result {
+        self.alphabet().write_alphabet_description(w)
+    }
+
+    fn write_acceptance<W: std::fmt::Write>(&self, w: &mut W) -> Result {
+        let (low, high) = self.low_and_high_priority();
+
+        OmegaAcceptanceCondition::Parity(low, high).write_hoa(w)
+    }
+}
+
+impl HoaSuitableAlphabet for CharAlphabet {
+    fn write_alphabet_description<W: std::fmt::Write>(&self, w: &mut W) -> Result {
+        write!(
+            w,
+            "AP: {} {}\n",
+            self.size(),
+            (0..self.size())
+                .map(|i| (('a' as u8) + (i as u8)) as char)
+                .map(|c| format!("\"{}\"", c))
+                .join(" ")
+        )
+    }
+
+    fn write_expression<W: std::fmt::Write>(&self, w: &mut W, expr: &Self::Expression) -> Result {
+        write!(
+            w,
+            "{}",
+            (0..self.size())
+                .map(|i| if i as u8 == (*expr as u8) - ('a' as u8) {
+                    format!("{i}")
+                } else {
+                    format!("!{i}")
+                })
+                .join(" & ")
+        )
+    }
+}
+
+impl HoaSuitableAlphabet for HoaAlphabet {
+    fn write_alphabet_description<W: std::fmt::Write>(&self, w: &mut W) -> Result {
+        write!(
+            w,
+            "AP: {} {}\n",
+            self.size(),
+            self.apnames()
+                .iter()
+                .map(|name| format!("\"{}\"", name))
+                .join(" ")
+        )
+    }
+
+    fn write_expression<W: std::fmt::Write>(&self, w: &mut W, expr: &Self::Expression) -> Result {
+        write!(w, "{}", expr.show())
+    }
+}
+
+/// Assumes that `low` is the least occurring and `high` is the highest occurring priority,
+/// *inclusive*.
+fn build_parity_condition_hoa(low: usize, high: usize) -> String {
+    let parity = low % 2;
+
+    if high <= low {
+        return match parity {
+            0 => "t".to_string(),
+            1 => "f".to_string(),
+            _ => unreachable!(),
+        };
+    }
+
+    match high - low {
+        0 => match parity {
+            0 => format!("Inf({low})"),
+            1 => format!("Fin({low})"),
+            _ => unreachable!(),
+        },
+        1 => match parity {
+            0 => format!("Inf({low}) | Fin({high})"),
+            1 => format!("Fin({low}) & Inf({high})"),
+            _ => unreachable!(),
+        },
+        _ => match parity {
+            0 => format!(
+                "Inf({low}) | ({})",
+                build_parity_condition_hoa(low + 1, high)
+            ),
+            1 => format!(
+                "Fin({low}) & ({})",
+                build_parity_condition_hoa(low + 1, high)
+            ),
+            _ => unreachable!(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TSBuilder, WriteHoa};
+
+    #[test]
+    fn build_parity_hoa_string() {
+        assert_eq!(
+            crate::hoa::output::build_parity_condition_hoa(0, 4),
+            "Inf(0) | (Fin(1) & (Inf(2) | (Fin(3) & Inf(4))))"
+        );
+        assert_eq!(
+            crate::hoa::output::build_parity_condition_hoa(0, 2),
+            "Inf(0) | (Fin(1) & Inf(2))"
+        );
+    }
+
+    #[test]
+    fn write_hoa_dpa() {
+        let dpa = TSBuilder::without_state_colors()
+            .with_edges([(0, 'a', 0, 0), (0, 'b', 1, 0), (0, 'c', 2, 0)])
+            .into_dpa(0);
+        let hoa = dpa.to_hoa();
+        assert_eq!(
+            hoa,
+            "HOA: v1\nAP: 3 \"a\" \"b\" \"c\"\nStates: 1\nStart: 0\nacc-name: parity min even 2\nAcceptance: Inf(0) | (Fin(1) & Inf(2))\n--BODY--\nState: 0\n[0 & !1 & !2] 0 {0}\n[!0 & 1 & !2] 0 {1}\n[!0 & !1 & 2] 0 {2}\n--END--\n"
+        );
+    }
 }

--- a/src/hoa/output.rs
+++ b/src/hoa/output.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use tracing::trace;
 
 use crate::prelude::*;
 
@@ -61,6 +62,7 @@ pub trait WriteHoa: TransitionSystem + Pointed {
     fn to_hoa(&self) -> String {
         let mut w = String::new();
         self.write_hoa(&mut w).unwrap();
+        trace!("produced HOA string from automaton\n{}", w);
         w
     }
 }
@@ -72,8 +74,9 @@ impl OmegaAcceptanceCondition {
                 let zero_based_range = high - low + (low % 2);
                 write!(
                     w,
-                    "acc-name: parity min even {}\nAcceptance: {}\n",
-                    zero_based_range,
+                    "acc-name: parity min even {}\nAcceptance: {} {}\n",
+                    zero_based_range + 1,
+                    zero_based_range + 1,
                     build_parity_condition_hoa(*low, *high)
                 )
             }
@@ -148,7 +151,7 @@ impl HoaSuitableAlphabet for HoaAlphabet {
         write!(
             w,
             "AP: {} {}\n",
-            self.size(),
+            self.apnames_len(),
             self.apnames()
                 .iter()
                 .map(|name| format!("\"{}\"", name))

--- a/src/hoa/output.rs
+++ b/src/hoa/output.rs
@@ -120,12 +120,12 @@ impl<A: HoaSuitableAlphabet> WriteHoa for DPA<A> {
 
 impl HoaSuitableAlphabet for CharAlphabet {
     fn write_alphabet_description<W: std::fmt::Write>(&self, w: &mut W) -> Result {
-        write!(
+        writeln!(
             w,
-            "AP: {} {}\n",
+            "AP: {} {}",
             self.size(),
             (0..self.size())
-                .map(|i| (('a' as u8) + (i as u8)) as char)
+                .map(|i| ((b'a') + (i as u8)) as char)
                 .map(|c| format!("\"{}\"", c))
                 .join(" ")
         )
@@ -136,7 +136,7 @@ impl HoaSuitableAlphabet for CharAlphabet {
             w,
             "{}",
             (0..self.size())
-                .map(|i| if i as u8 == (*expr as u8) - ('a' as u8) {
+                .map(|i| if i as u8 == (*expr as u8) - (b'a') {
                     format!("{i}")
                 } else {
                     format!("!{i}")
@@ -148,9 +148,9 @@ impl HoaSuitableAlphabet for CharAlphabet {
 
 impl HoaSuitableAlphabet for HoaAlphabet {
     fn write_alphabet_description<W: std::fmt::Write>(&self, w: &mut W) -> Result {
-        write!(
+        writeln!(
             w,
-            "AP: {} {}\n",
+            "AP: {} {}",
             self.apnames_len(),
             self.apnames()
                 .iter()
@@ -226,7 +226,7 @@ mod tests {
         let hoa = dpa.to_hoa();
         assert_eq!(
             hoa,
-            "HOA: v1\nAP: 3 \"a\" \"b\" \"c\"\nStates: 1\nStart: 0\nacc-name: parity min even 2\nAcceptance: Inf(0) | (Fin(1) & Inf(2))\n--BODY--\nState: 0\n[0 & !1 & !2] 0 {0}\n[!0 & 1 & !2] 0 {1}\n[!0 & !1 & 2] 0 {2}\n--END--\n"
+            "HOA: v1\nAP: 3 \"a\" \"b\" \"c\"\nStates: 1\nStart: 0\nacc-name: parity min even 3\nAcceptance: 3 Inf(0) | (Fin(1) & Inf(2))\n--BODY--\nState: 0\n[0 & !1 & !2] 0 {0}\n[!0 & 1 & !2] 0 {1}\n[!0 & !1 & 2] 0 {2}\n--END--\n"
         );
     }
 }

--- a/src/transition_system.rs
+++ b/src/transition_system.rs
@@ -123,9 +123,9 @@ pub trait TransitionSystem: Sized {
     }
 
     /// Helper function which creates an expression from the given symbol.
-    /// This is a convenience function that simply calls [`Alphabet::expression`].
+    /// This is a convenience function that simply calls [`Alphabet::make_expression`].
     fn make_expression(&self, sym: SymbolOf<Self>) -> ExpressionOf<Self> {
-        <Self::Alphabet as Alphabet>::expression(sym)
+        self.alphabet().make_expression(sym)
     }
 
     /// Gives an iterator over all transitions of `self`.

--- a/src/transition_system/edge.rs
+++ b/src/transition_system/edge.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::prelude::*;
 
 /// This trait is implemented for references to transitions, so that they can be used in

--- a/src/transition_system/operations/quotient.rs
+++ b/src/transition_system/operations/quotient.rs
@@ -99,7 +99,7 @@ impl<Ts: TransitionSystem> Quotient<Ts> {
             expressions: ts
                 .alphabet()
                 .universe()
-                .map(|sym| (sym, <Ts::Alphabet as Alphabet>::expression(sym)))
+                .map(|sym| (sym, ts.alphabet().make_expression(sym).clone()))
                 .collect(),
             ts,
             partition,


### PR DESCRIPTION
This PR makes it so that the `hoars` dependency lives in a subfolder, i.e. it is bundled in this repo. Further, it introduces:
- parsing of HOA automata (provided they are `colored`, meaning every edge obtains precisely one acceptance set)
- conversion between automata with HOA alphabet and with `CharAlphabet` (provided the char alphabet uses an alphabet whose size is a power of 2)
- a binary `oai` that at the moment has only the subcommand `todpa` which parses a HOA DPA, converts it to a DPA over a `CharAlphabet` and back and then outputs this DPA to stdout. The purpose is to allow for testing using `autcross` and `randaut`

Finally, it fixes some problems in the `hoars` library. Specifically, the parsed `HoaSymbol`s/`HoaExpression`s always had 8 APs, they now correctly relate to the alphabet. For this, an `AbstractLabelExpression` type (enum) was introduced.