### PR TITLE
Remove most of the `allow(unused)` directives

### DIFF
--- a/hoars/src/body.rs
+++ b/hoars/src/body.rs
@@ -167,6 +167,8 @@ fn explicit_edge() -> impl Parser<Token, ExplicitEdge, Error = Simple<Token>> {
         })
 }
 
+// For now, we allow only explicit edges, but this might change in the future. In any case, we already have the necessary
+// infrastructure to support implicit edges.
 #[allow(unused)]
 fn implicit_edge() -> impl Parser<Token, ImplicitEdge, Error = Simple<Token>> {
     value::state_conjunction()

--- a/src/automaton/omega.rs
+++ b/src/automaton/omega.rs
@@ -88,7 +88,6 @@ pub struct OmegaAutomaton<A: Alphabet> {
 
 pub struct DeterministicOmegaAutomaton<A: Alphabet> {
     pub(super) ts: Initialized<DTS<A, usize, AcceptanceMask>>,
-    #[allow(unused)]
     pub(super) acc: OmegaAcceptanceCondition,
 }
 

--- a/src/congruence.rs
+++ b/src/congruence.rs
@@ -9,12 +9,13 @@ pub use class::Class;
 mod forc;
 pub use forc::FORC;
 
-#[allow(unused)]
 mod transitionprofile;
-pub use transitionprofile::{Accumulates, RunProfile, RunSignature, TransitionMonoid};
+pub use transitionprofile::{
+    Accumulates, ReducingMonoid, ReplacingMonoid, RunProfile, RunSignature, TransitionMonoid,
+};
 
-#[allow(unused)]
 mod cayley;
+pub use cayley::{Cayley, RightCayley};
 
 /// Represents a right congruence relation, which is in essence a trim, deterministic
 /// transition system with a designated initial state.

--- a/src/congruence/cayley.rs
+++ b/src/congruence/cayley.rs
@@ -7,41 +7,60 @@ use super::{
     Accumulates, RunProfile, TransitionMonoid,
 };
 
+/// Represents the two-sided Cayley graph of a deterministic transition system.
+/// In essence, it is a graph using transition profiles of the ts as nodes. It uses
+/// a [`Directional`] alphabet to represent concatenation both from the left and the right.
+///
+/// There are different ways of building the Cayley graph. The most important distinction
+/// lies in how two colours are combined, which is determined through the [`Accumulates`] trait.
+/// Specifically, the Cayley graph associates a finite word `w` with a transition profile `tp`
+/// that describes the behaviour of `w` when applied to/read from any state of the transition system.
+///
+/// The transformation on the state itself is straightforward as the transition profile can simply
+/// store which state is reached. However the encountered edge and state colours need to be taken
+/// into account as well. The [`Accumulates`] trait provides a way to combine these colours.
+///
+/// There are two main ways to combine the colours:
+/// - `Reduces`: This struct takes the minimum of the currently stored/known and any encountered value.
+/// - `Replaces`: This struct stores any encountered value and replaces the currently stored value.
+/// - `Collect` (not yet implemented): This struct collects all encountered values.
 #[derive(Clone)]
 pub struct Cayley<
-    'a,
     Ts: Deterministic<Alphabet = CharAlphabet> + Pointed,
     SA: Accumulates<X = Ts::StateColor>,
     EA: Accumulates<X = Ts::EdgeColor>,
 > {
-    #[allow(unused)]
-    ts: &'a Ts,
     alphabet: Directional,
     expressions: crate::Map<SymbolOf<Self>, ExpressionOf<Self>>,
-    m: TransitionMonoid<'a, Ts, SA, EA>,
+    m: TransitionMonoid<Ts, SA, EA>,
+}
+
+/// The right Cayley graph of a deterministic transition system is a graph that uses
+/// the transition profiles of the ts as nodes. See [`Cayley`] for more details.
+#[derive(Clone)]
+pub struct RightCayley<
+    Ts: TransitionSystem + Pointed,
+    SA: Accumulates<X = Ts::StateColor>,
+    EA: Accumulates<X = Ts::EdgeColor>,
+> {
+    expressions: crate::Map<SymbolOf<Ts>, ExpressionOf<Ts>>,
+    m: TransitionMonoid<Ts, SA, EA>,
 }
 
 impl<
-        'a,
         Ts: Deterministic<Alphabet = CharAlphabet> + Pointed,
         SA: Accumulates<X = Ts::StateColor>,
         EA: Accumulates<X = Ts::EdgeColor>,
-    > Cayley<'a, Ts, SA, EA>
+    > Cayley<Ts, SA, EA>
 {
-    /// Returns a reference to the underlying transition system.
-    #[allow(unused)]
-    pub fn ts(&self) -> &Ts {
-        self.ts
-    }
-
-    /// returns a reference to the [`TransitionMonoid`].
-    pub fn monoid(&self) -> &TransitionMonoid<'a, Ts, SA, EA> {
+    /// Returns a reference to the [`TransitionMonoid`].
+    pub fn monoid(&self) -> &TransitionMonoid<Ts, SA, EA> {
         &self.m
     }
 }
 
-impl<'a, Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>>
-    TransitionSystem for Cayley<'a, Ts, SA, EA>
+impl<Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>> TransitionSystem
+    for Cayley<Ts, SA, EA>
 where
     Ts: Deterministic<Alphabet = CharAlphabet> + Pointed,
 {
@@ -78,8 +97,8 @@ where
     }
 }
 
-impl<'a, Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>> Deterministic
-    for Cayley<'a, Ts, SA, EA>
+impl<Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>> Deterministic
+    for Cayley<Ts, SA, EA>
 where
     Ts: Deterministic<Alphabet = CharAlphabet> + Pointed,
 {
@@ -102,91 +121,78 @@ where
     }
 }
 
-impl<'a, Ts> Cayley<'a, Ts, Reduces<Ts::StateColor>, Reduces<Ts::EdgeColor>>
+impl<Ts> Cayley<Ts, Reduces<Ts::StateColor>, Reduces<Ts::EdgeColor>>
 where
     Ts: Deterministic<Alphabet = CharAlphabet> + Pointed,
     Reduces<Ts::EdgeColor>: Accumulates<X = Ts::EdgeColor>,
     Reduces<Ts::StateColor>: Accumulates<X = Ts::StateColor>,
 {
-    #[allow(unused)]
-    pub fn new_reducing(ts: &'a Ts) -> Self {
+    /// Instantiates a new Cayley graph that reduces the state and edge colors. Specifically,
+    /// this means that the state and edge colors are accumulated by taking the minimum of the
+    /// currently stored/known and any encountered value.
+    pub fn new_reducing(ts: Ts) -> Self {
         let alphabet = Directional::from_iter(ts.alphabet().universe());
         Cayley {
             expressions: alphabet.expression_map(),
-            ts,
-            alphabet,
             m: TransitionMonoid::new_reducing(ts),
+            alphabet,
         }
     }
 }
-impl<'a, Ts> Cayley<'a, Ts, Replaces<Ts::StateColor>, Replaces<Ts::EdgeColor>>
+impl<Ts> Cayley<Ts, Replaces<Ts::StateColor>, Replaces<Ts::EdgeColor>>
 where
     Ts: Deterministic<Alphabet = CharAlphabet> + Pointed,
     Replaces<Ts::EdgeColor>: Accumulates<X = Ts::EdgeColor>,
     Replaces<Ts::StateColor>: Accumulates<X = Ts::StateColor>,
 {
-    #[allow(unused)]
-    pub fn new_replacing(ts: &'a Ts) -> Self {
+    /// Instantiates a new Cayley graph that replaces the state and edge colors. This means
+    /// any encountered value is stored and replaces the currently stored value.
+    pub fn new_replacing(ts: Ts) -> Self {
         let alphabet = Directional::from_iter(ts.alphabet().universe());
         Cayley {
             expressions: alphabet.expression_map(),
-            ts,
             alphabet,
             m: TransitionMonoid::new_replacing(ts),
         }
     }
 }
 
-impl<'a, Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>>
-    Cayley<'a, Ts, SA, EA>
+impl<Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>> Cayley<Ts, SA, EA>
 where
     Ts: Deterministic<Alphabet = CharAlphabet> + Pointed,
     Ts::StateColor: Accumulates,
     Ts::EdgeColor: Accumulates,
 {
-    pub fn from(ts: &'a Ts, m: TransitionMonoid<'a, Ts, SA, EA>) -> Self {
+    /// Builds a new Cayley graph from the given transition system and transition monoid.
+    pub fn from(ts: Ts, m: TransitionMonoid<Ts, SA, EA>) -> Self {
         let alphabet = Directional::from_iter(ts.alphabet().universe());
         Self {
             expressions: alphabet.expression_map(),
-            ts,
             alphabet,
             m,
         }
     }
 }
 
-// Now for a more specific, guaranteed working right cayley impl
-
-#[derive(Clone)]
-pub struct RightCayley<
-    'a,
-    Ts: TransitionSystem + Pointed,
-    SA: Accumulates<X = Ts::StateColor>,
-    EA: Accumulates<X = Ts::EdgeColor>,
-> {
-    ts: &'a Ts,
-    expressions: crate::Map<SymbolOf<Ts>, ExpressionOf<Ts>>,
-    m: TransitionMonoid<'a, Ts, SA, EA>,
-}
-
 impl<
-        'a,
         Ts: TransitionSystem + Pointed,
         SA: Accumulates<X = Ts::StateColor>,
         EA: Accumulates<X = Ts::EdgeColor>,
-    > RightCayley<'a, Ts, SA, EA>
+    > RightCayley<Ts, SA, EA>
 {
+    /// Returns a reference to the underlying ts.
     pub fn ts(&self) -> &Ts {
-        self.ts
+        self.m.ts()
     }
 
-    pub fn monoid(&self) -> &TransitionMonoid<'a, Ts, SA, EA> {
+    /// Returns a reference to the [`TransitionMonoid`].
+    pub fn monoid(&self) -> &TransitionMonoid<Ts, SA, EA> {
         &self.m
     }
 }
 
-impl<'a, Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>>
-    TransitionSystem for RightCayley<'a, Ts, SA, EA>
+impl<Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>> TransitionSystem
+    for RightCayley<Ts, SA, EA>
 where
     Ts: Deterministic + Pointed,
 {
@@ -205,7 +211,7 @@ where
     type Alphabet = Ts::Alphabet;
 
     fn alphabet(&self) -> &Self::Alphabet {
-        self.ts.alphabet()
+        self.ts().alphabet()
     }
 
     fn state_indices(&self) -> Self::StateIndices<'_> {
@@ -222,8 +228,8 @@ where
     }
 }
 
-impl<'a, Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>> Deterministic
-    for RightCayley<'a, Ts, SA, EA>
+impl<Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>> Deterministic
+    for RightCayley<Ts, SA, EA>
 where
     Ts: Deterministic + Pointed,
 {
@@ -233,7 +239,7 @@ where
         symbol: SymbolOf<Self>,
     ) -> Option<Self::EdgeRef<'_>> {
         let idx = state.to_index(self)?;
-        let (tp, string) = self.monoid().get_profile(idx)?;
+        let (_tp, string) = self.monoid().get_profile(idx)?;
         let mut word = string.to_vec();
         word.push(symbol);
         let tp = self.monoid().profile_for(&word)?;
@@ -246,46 +252,49 @@ where
     }
 }
 
-impl<'a, Ts> RightCayley<'a, Ts, Reduces<Ts::StateColor>, Reduces<Ts::EdgeColor>>
+impl<Ts> RightCayley<Ts, Reduces<Ts::StateColor>, Reduces<Ts::EdgeColor>>
 where
     Ts: Deterministic + Pointed,
     Reduces<Ts::EdgeColor>: Accumulates<X = Ts::EdgeColor>,
     Reduces<Ts::StateColor>: Accumulates<X = Ts::StateColor>,
 {
-    pub fn new_reducing(ts: &'a Ts) -> Self {
+    /// Instantiates a new right Cayley graph that reduces the state and edge colors. Specifically,
+    /// this means that the state and edge colors are accumulated by taking the minimum of the currently
+    /// stored/known and any encountered value.
+    pub fn new_reducing(ts: Ts) -> Self {
         RightCayley {
             expressions: ts.alphabet().expression_map(),
-            ts,
             m: TransitionMonoid::new_reducing(ts),
         }
     }
 }
-impl<'a, Ts> RightCayley<'a, Ts, Replaces<Ts::StateColor>, Replaces<Ts::EdgeColor>>
+impl<Ts> RightCayley<Ts, Replaces<Ts::StateColor>, Replaces<Ts::EdgeColor>>
 where
     Ts: Deterministic + Pointed,
     Replaces<Ts::EdgeColor>: Accumulates<X = Ts::EdgeColor>,
     Replaces<Ts::StateColor>: Accumulates<X = Ts::StateColor>,
 {
-    pub fn new_replacing(ts: &'a Ts) -> Self {
+    /// Instantiates a new right Cayley graph that replaces the state and edge colors. This means
+    /// any encountered value is stored and replaces the currently stored value.
+    pub fn new_replacing(ts: Ts) -> Self {
         RightCayley {
             expressions: ts.alphabet().expression_map(),
-            ts,
             m: TransitionMonoid::new_replacing(ts),
         }
     }
 }
 
-impl<'a, Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>>
-    RightCayley<'a, Ts, SA, EA>
+impl<Ts, SA: Accumulates<X = Ts::StateColor>, EA: Accumulates<X = Ts::EdgeColor>>
+    RightCayley<Ts, SA, EA>
 where
     Ts: TransitionSystem + Pointed,
     Ts::StateColor: Accumulates,
     Ts::EdgeColor: Accumulates,
 {
-    pub fn from(ts: &'a Ts, m: TransitionMonoid<'a, Ts, SA, EA>) -> Self {
+    /// Builds a new right Cayley graph from the given transition system and transition monoid.
+    pub fn from(ts: Ts, m: TransitionMonoid<Ts, SA, EA>) -> Self {
         Self {
             expressions: ts.alphabet().expression_map(),
-            ts,
             m,
         }
     }
@@ -293,7 +302,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, tests::wiki_dfa};
+    use crate::tests::wiki_dfa;
 
     #[test]
     #[ignore]

--- a/src/hoa.rs
+++ b/src/hoa.rs
@@ -322,15 +322,12 @@ impl Show for HoaExpression {
 
 pub struct HoaExpressionIter<'a> {
     iter: BddSatisfyingValuations<'a>,
-    #[allow(unused)]
-    aps: usize,
 }
 
 impl<'a> HoaExpressionIter<'a> {
     pub fn new(expr: &'a HoaExpression) -> Self {
         Self {
             iter: expr.bdd.sat_valuations(),
-            aps: expr.aps,
         }
     }
 }

--- a/src/transition_system.rs
+++ b/src/transition_system.rs
@@ -489,6 +489,19 @@ pub trait TransitionSystem: Sized {
         tarjan_scc_iterative(self)
     }
 
+    /// Performs an SCC decomposition of self using Kosaraju's algorithm, starting from the state `start`. This is an
+    /// efficient algorithm and it might provide more performance over Tarjan's algorithm in some cases.
+    fn sccs_kosaraju(
+        &self,
+        start: Self::StateIndex,
+    ) -> connected_components::SccDecomposition<'_, Self>
+    where
+        Self: Sized,
+        Self: PredecessorIterable,
+    {
+        connected_components::kosaraju(self, start)
+    }
+
     /// Obtains the [`connected_components::SccDecomposition`] of self, which is a partition of the states into strongly
     /// connected components. Uses Tarjan's algorithm.
     fn sccs_recursive(&self) -> connected_components::SccDecomposition<'_, Self>

--- a/src/transition_system/connected_components.rs
+++ b/src/transition_system/connected_components.rs
@@ -7,7 +7,7 @@ mod scc;
 pub use scc::Scc;
 
 mod tarjan;
-pub use tarjan::{tarjan_scc_iterative, tarjan_scc_recursive};
+pub use tarjan::{kosaraju, tarjan_scc_iterative, tarjan_scc_recursive};
 
 mod tarjan_dag;
 pub use tarjan_dag::TarjanDAG;

--- a/src/transition_system/connected_components/tarjan.rs
+++ b/src/transition_system/connected_components/tarjan.rs
@@ -136,7 +136,7 @@ where
     SccDecomposition::new(ts, sccs)
 }
 
-#[allow(unused)]
+/// Implementation of Kosaraju's algorithm for computing the SCC decomposition.
 pub fn kosaraju<Ts>(ts: &Ts, start: Ts::StateIndex) -> SccDecomposition<'_, Ts>
 where
     Ts: TransitionSystem + PredecessorIterable,

--- a/src/transition_system/impls/hash_ts.rs
+++ b/src/transition_system/impls/hash_ts.rs
@@ -67,13 +67,11 @@ impl<A: Alphabet, Idx: IndexType, C: Clone + Hash + Eq, Q: Clone> HashTs<A, Q, C
     }
 
     /// Creates a `HASHTS` from the given alphabet and states.
-    #[allow(unused)]
     pub(crate) fn from_parts(alphabet: A, states: Map<Idx, HashTsState<A, Q, C, Idx>>) -> Self {
         Self { alphabet, states }
     }
 
     /// Decomposes the `HASHTS` into its constituent parts.
-    #[allow(unused)]
     #[allow(clippy::type_complexity)]
     pub(crate) fn into_parts(self) -> (A, Map<Idx, HashTsState<A, Q, C, Idx>>) {
         (self.alphabet, self.states)
@@ -135,7 +133,6 @@ impl<A: Alphabet, Idx: IndexType, C: Clone + Hash + Eq, Q: Clone> HashTs<A, Q, C
 
 impl<A: Alphabet, Idx: IndexType, Q: Clone, C: Clone + Hash + Eq> HashTs<A, Q, C, Idx> {
     /// Returns an iterator over the [`EdgeIndex`]es of the edges leaving the given state.
-    #[allow(unused)]
     pub(crate) fn index_ts_edges_from(
         &self,
         source: Idx,

--- a/src/transition_system/operations/product.rs
+++ b/src/transition_system/operations/product.rs
@@ -121,8 +121,7 @@ pub struct ProductStatesIter<'a, L: TransitionSystem, R: TransitionSystem> {
     left: L::StateIndices<'a>,
     right: R::StateIndices<'a>,
     left_state: Option<L::StateIndex>,
-    #[allow(unused)]
-    lts: &'a L,
+    _lts: &'a L,
     rts: &'a R,
 }
 
@@ -154,7 +153,7 @@ impl<'a, L: TransitionSystem, R: TransitionSystem> ProductStatesIter<'a, L, R> {
             left: lit,
             right: rts.state_indices(),
             rts,
-            lts,
+            _lts: lts,
         }
     }
 }

--- a/src/transition_system/operations/quotient.rs
+++ b/src/transition_system/operations/quotient.rs
@@ -62,28 +62,6 @@ impl<Ts: TransitionSystem> Quotient<Ts> {
         self.partition.iter().position(|o| o.contains(&q))
     }
 
-    #[allow(unused)]
-    fn sanity_check(ts: &Ts, partition: &Partition<Ts::StateIndex>) -> bool {
-        for p in partition.iter() {
-            let all_equal = p
-                .iter()
-                .map(|i| {
-                    ts.edges_from(*i)
-                        .map(|it| {
-                            it.map(|tt| (tt.expression().clone(), tt.target()))
-                                .collect::<Set<_>>()
-                        })
-                        .unwrap_or_default()
-                })
-                .all_equal();
-            if !all_equal {
-                panic!("SANITY CHECK FAILED:\n{:?}", partition);
-                return false;
-            }
-        }
-        true
-    }
-
     /// Extracts the underlying right congruence by erasing the state and edge colors and then collecting
     /// into a [`RightCongruence`].
     pub fn underlying_right_congruence(self, _ts: &Ts) -> RightCongruence<Ts::Alphabet>

--- a/src/transition_system/reachable.rs
+++ b/src/transition_system/reachable.rs
@@ -11,8 +11,6 @@ pub type MinimalRepresentative<Ts> = (Vec<SymbolOf<Ts>>, <Ts as TransitionSystem
 #[derive(Debug, Clone)]
 pub struct MinimalRepresentatives<Ts: TransitionSystem> {
     ts: Ts,
-    #[allow(unused)]
-    origin: Ts::StateIndex,
     seen: Set<Ts::StateIndex>,
     queue: VecDeque<MinimalRepresentative<Ts>>,
 }
@@ -25,12 +23,7 @@ where
     pub fn new(ts: Ts, origin: Ts::StateIndex) -> Self {
         let seen = Set::from_iter([origin]);
         let queue = [(vec![], origin)].into_iter().collect();
-        Self {
-            ts,
-            origin,
-            seen,
-            queue,
-        }
+        Self { ts, seen, queue }
     }
 }
 

--- a/src/word/finite.rs
+++ b/src/word/finite.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::{prelude::Symbol, Show};
 
-use super::{Concat, LinearWord, PeriodicOmegaWord};
+use super::{omega::OmegaIteration, Concat, LinearWord, PeriodicOmegaWord};
 
 /// A finite word is a [`LinearWord`] that has a finite length.
 pub trait FiniteWord<S>: LinearWord<S> {
@@ -65,6 +65,20 @@ pub trait FiniteWord<S>: LinearWord<S> {
             "Omega iteration of an empty word is undefined!"
         );
         PeriodicOmegaWord::new(self)
+    }
+
+    /// Provides a thin wrapper around a finite word that represents the omega (infinite)
+    /// iteration of it.
+    fn omega_iteration(self) -> OmegaIteration<Self>
+    where
+        Self: Sized,
+        S: Symbol,
+    {
+        assert!(
+            !self.is_empty(),
+            "Omega iteration of an empty word is undefined!"
+        );
+        OmegaIteration::new(self)
     }
 
     /// Gives the length of the word, i.e. the number of symbols.

--- a/src/word/omega.rs
+++ b/src/word/omega.rs
@@ -506,7 +506,6 @@ pub struct OmegaIteration<W>(W);
 
 impl<W> OmegaIteration<W> {
     /// Iterate the given finite word `from`, panics if the word is empty.
-    #[allow(unused)]
     pub fn new<S: Symbol>(from: W) -> Self
     where
         W: FiniteWord<S>,


### PR DESCRIPTION
A few remain. Some are there to hide implementation details for different transition systems. Others are in random generation module as we do not really have a good use for those methods. Finally, there are also some in the `hoars` submodule because they implement functionality like implicit edges that is just not used yet.