### PR TITLE
Implement Rabin and Muller automata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 fxhash = "0.2"
-itertools = "0.12"
+itertools = "0.13.0"
 tabled = { version = "0.15", features = ["ansi"] }
 owo-colors = "4.0"
 test-log = { version = "0.2", features = ["trace"] }

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -14,19 +14,12 @@ pub use mealy::{IntoMealyMachine, MealyMachine, MealySemantics};
 mod dfa;
 pub use dfa::{DFASemantics, IntoDFA, DFA};
 
-mod dpa;
-pub use dpa::{
-    IntoDPA, MaxEvenParitySemantics, MaxOddParitySemantics, MinEvenParitySemantics,
-    MinOddParitySemantics, DPA,
-};
-
-mod dba;
-pub use dba::{DBASemantics, IntoDBA, DBA};
-
 #[allow(missing_docs)]
 mod omega;
 pub use omega::{
-    AcceptanceMask, DeterministicOmegaAutomaton, OmegaAcceptanceCondition, OmegaAutomaton,
+    AcceptanceMask, DBASemantics, DeterministicOmegaAutomaton, IntoDBA, IntoDPA,
+    MaxEvenParitySemantics, MaxOddParitySemantics, MinEvenParitySemantics, MinOddParitySemantics,
+    OmegaAcceptanceCondition, OmegaAutomaton, DBA, DPA,
 };
 
 mod with_initial;

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -11,19 +11,19 @@ pub use moore::{IntoMooreMachine, MooreMachine, MooreSemantics};
 mod mealy;
 pub use mealy::{IntoMealyMachine, MealyMachine, MealySemantics};
 
-mod dfa;
-pub use dfa::{DFASemantics, IntoDFA, DFA};
+mod reachability;
+pub use reachability::{IntoDFA, ReachabilityCondition, DFA};
 
-#[allow(missing_docs)]
 mod omega;
 pub use omega::{
-    AcceptanceMask, DBASemantics, DeterministicOmegaAutomaton, IntoDBA, IntoDPA,
-    MaxEvenParitySemantics, MaxOddParitySemantics, MinEvenParitySemantics, MinOddParitySemantics,
-    OmegaAcceptanceCondition, OmegaAutomaton, DBA, DPA,
+    AcceptanceMask, BuchiCondition, DeterministicOmegaAutomaton, IntoDBA, IntoDMA, IntoDPA,
+    IntoDRA, MaxEvenParityCondition, MaxOddParityCondition, MinEvenParityCondition,
+    MinOddParityCondition, MullerCondition, OmegaAcceptanceCondition, OmegaAutomaton,
+    RabinCondition, RabinPair, DBA, DMA, DPA, DRA,
 };
 
 mod with_initial;
-pub use with_initial::WithInitial;
+pub use with_initial::{WithInitial, WithoutCondition};
 
 mod semantics;
 pub use semantics::{FiniteSemantics, OmegaSemantics, Semantics};

--- a/src/automaton/omega.rs
+++ b/src/automaton/omega.rs
@@ -1,7 +1,3 @@
-use bit_set::BitSet;
-use itertools::Itertools;
-use tracing::error;
-
 use crate::{hoa::HoaAlphabet, prelude::*, Set};
 
 mod buchi;
@@ -16,56 +12,16 @@ pub use rabin::*;
 mod muller;
 pub use muller::*;
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct AcceptanceMask(BitSet);
+#[allow(missing_docs)]
+mod acceptance_mask;
+pub use acceptance_mask::AcceptanceMask;
 
-impl AcceptanceMask {
-    pub fn max(&self) -> Option<usize> {
-        self.iter().max()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
-        self.0.iter()
-    }
-
-    pub fn min(&self) -> Option<usize> {
-        self.iter().min()
-    }
-
-    pub fn as_priority(&self) -> usize {
-        let mut it = self.iter();
-        let Some(priority) = it.next() else {
-            error!(
-                "no priority is set on the edge, we require each edge to have precisely one color"
-            );
-            panic!("could not extract priority from acceptance mask");
-        };
-        if it.next().is_some() {
-            error!(
-                "more than one priority is set on the edge: {:?}, but we require edges to have precisely one color",
-                self.0
-            );
-            panic!("could not extract priority from acceptance mask");
-        }
-        priority
-    }
-}
-
-impl Show for AcceptanceMask {
-    fn show(&self) -> String {
-        self.iter().map(|i| format!("{{{i}}}")).join(", ")
-    }
-}
-
-impl From<&hoars::AcceptanceSignature> for AcceptanceMask {
-    fn from(value: &hoars::AcceptanceSignature) -> Self {
-        Self(BitSet::from_iter(value.iter().map(|&i| {
-            i.try_into().expect("Could not cast {i} to usize")
-        })))
-    }
-}
-
+/// Disambiguates between the different types of acceptance conditions. This is only
+/// used in conjunction with [`OmegaAutomaton`]/[`DeterministicOmegaAutomaton`] when
+/// the exact type is not known beforehand (such as when parsing an automaton). Usually
+/// one should prefer using specific automaton types such as [`DBA`]/[`DPA`] etc.
 #[derive(Debug, Clone, Eq, Copy, PartialEq, Ord, PartialOrd)]
+#[allow(missing_docs)]
 pub enum OmegaAcceptanceCondition {
     Parity(usize, usize),
     Buchi,
@@ -78,6 +34,8 @@ pub enum OmegaAcceptanceCondition {
 }
 
 impl OmegaAcceptanceCondition {
+    /// Returns true if and only if the condition is satisfied by the given set of
+    /// [`AcceptanceMask`]s.
     pub fn satisfied(&self, infset: &Set<AcceptanceMask>) -> bool {
         match self {
             OmegaAcceptanceCondition::Parity(_low, _high) => infset
@@ -91,12 +49,17 @@ impl OmegaAcceptanceCondition {
     }
 }
 
+/// Represents a generic omega automaton, i.e. an automaton over infinite words.
+/// This type is mainly used when the exact type of automaton is not known beforehand
+/// such as when parsing automata. One should prefer using specific types such as
+/// [`DPA`] whenever possible.
 pub struct OmegaAutomaton<A: Alphabet> {
     pub(super) ts: NTS<A, usize, AcceptanceMask>,
     pub(super) initial: usize,
     pub(super) acc: OmegaAcceptanceCondition,
 }
 
+/// A deterministic variant of [`OmegaAutomaton`].
 pub struct DeterministicOmegaAutomaton<A: Alphabet> {
     pub(super) ts: DTS<A, usize, AcceptanceMask>,
     pub(super) initial: usize,
@@ -104,6 +67,8 @@ pub struct DeterministicOmegaAutomaton<A: Alphabet> {
 }
 
 impl<A: Alphabet> OmegaAutomaton<A> {
+    /// Creates a new instance from the given transition system, initial state and
+    /// acceptance condition.
     pub fn new(
         ts: NTS<A, usize, AcceptanceMask>,
         initial: usize,
@@ -112,12 +77,17 @@ impl<A: Alphabet> OmegaAutomaton<A> {
         Self { ts, initial, acc }
     }
 
+    /// Attempts to convert `self` into a [`DeterministicOmegaAutomaton`]. Returns
+    /// `None` if this is not possible because the transition system underlying `self`
+    /// is not deterministic.
     pub fn into_deterministic(self) -> Option<DeterministicOmegaAutomaton<A>> {
         self.try_into().ok()
     }
 }
 
 impl<A: Alphabet> DeterministicOmegaAutomaton<A> {
+    /// Creates a new instance from the given *deterministic* transition system,
+    /// initial state and acceptance condition.
     pub fn new(
         ts: DTS<A, usize, AcceptanceMask>,
         initial: usize,
@@ -126,6 +96,8 @@ impl<A: Alphabet> DeterministicOmegaAutomaton<A> {
         Self { ts, initial, acc }
     }
 
+    /// Consumes and converts `self` into a [`DPA`]. Since [`DPA`]s can capture the
+    /// full class of omega-regular languages, this operation never fails.
     pub fn into_dpa(self) -> DPA<A> {
         assert!(
             matches!(self.acc, OmegaAcceptanceCondition::Parity(_, _)),

--- a/src/automaton/omega.rs
+++ b/src/automaton/omega.rs
@@ -4,6 +4,18 @@ use tracing::error;
 
 use crate::{hoa::HoaAlphabet, prelude::*, Set};
 
+mod buchi;
+pub use buchi::*;
+
+mod parity;
+pub use parity::*;
+
+mod rabin;
+pub use rabin::*;
+
+mod muller;
+pub use muller::*;
+
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct AcceptanceMask(BitSet);
 

--- a/src/automaton/omega/acceptance_mask.rs
+++ b/src/automaton/omega/acceptance_mask.rs
@@ -1,0 +1,54 @@
+use bit_set::BitSet;
+use itertools::Itertools;
+use tracing::error;
+
+use crate::Show;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct AcceptanceMask(BitSet);
+
+impl AcceptanceMask {
+    pub fn max(&self) -> Option<usize> {
+        self.iter().max()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
+        self.0.iter()
+    }
+
+    pub fn min(&self) -> Option<usize> {
+        self.iter().min()
+    }
+
+    pub fn as_priority(&self) -> usize {
+        let mut it = self.iter();
+        let Some(priority) = it.next() else {
+            error!(
+                "no priority is set on the edge, we require each edge to have precisely one color"
+            );
+            panic!("could not extract priority from acceptance mask");
+        };
+        if it.next().is_some() {
+            error!(
+                "more than one priority is set on the edge: {:?}, but we require edges to have precisely one color",
+                self.0
+            );
+            panic!("could not extract priority from acceptance mask");
+        }
+        priority
+    }
+}
+
+impl Show for AcceptanceMask {
+    fn show(&self) -> String {
+        self.iter().map(|i| format!("{{{i}}}")).join(", ")
+    }
+}
+
+impl From<&hoars::AcceptanceSignature> for AcceptanceMask {
+    fn from(value: &hoars::AcceptanceSignature) -> Self {
+        Self(BitSet::from_iter(value.iter().map(|&i| {
+            i.try_into().expect("Could not cast {i} to usize")
+        })))
+    }
+}

--- a/src/automaton/omega/buchi.rs
+++ b/src/automaton/omega/buchi.rs
@@ -10,13 +10,13 @@ use crate::prelude::*;
 /// This type will rarely be used on its own, for the automaton that makes
 /// use of it, see [`DBA`].
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
-pub struct DBASemantics;
+pub struct BuchiCondition;
 
-impl<Q> Semantics<Q, bool> for DBASemantics {
+impl<Q> Semantics<Q, bool> for BuchiCondition {
     type Output = bool;
 }
 
-impl<Q> OmegaSemantics<Q, bool> for DBASemantics {
+impl<Q> OmegaSemantics<Q, bool> for BuchiCondition {
     fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: OmegaRun<StateColor = Q, EdgeColor = bool>,
@@ -33,9 +33,9 @@ impl<Q> OmegaSemantics<Q, bool> for DBASemantics {
 ///
 /// In a certain sense, it is a special case of a deterministic parity automaton [`super::DPA`] with
 /// min even and priorities 0 and 1.
-pub type DBA<A = CharAlphabet> = Automaton<DTS<A, Void, bool>, DBASemantics, true>;
+pub type DBA<A = CharAlphabet> = Automaton<DTS<A, Void, bool>, BuchiCondition, true>;
 /// Helper trait for creating a [`DBA`] from a given transition system.
-pub type IntoDBA<T> = Automaton<T, DBASemantics, true>;
+pub type IntoDBA<T> = Automaton<T, BuchiCondition, true>;
 
 impl<C> IntoDBA<C>
 where

--- a/src/automaton/omega/buchi.rs
+++ b/src/automaton/omega/buchi.rs
@@ -21,7 +21,7 @@ impl<Q> OmegaSemantics<Q, bool> for DBASemantics {
     where
         R: OmegaRun<StateColor = Q, EdgeColor = bool>,
     {
-        run.infinity_edge_colors()
+        run.recurring_edge_colors_iter()
             .map(|mut colors| colors.any(|b| b))
             .unwrap_or(false)
     }

--- a/src/automaton/omega/muller.rs
+++ b/src/automaton/omega/muller.rs
@@ -1,0 +1,103 @@
+use std::collections::BTreeSet;
+
+use crate::math::Set;
+
+use crate::prelude::*;
+
+/// A deterministic Muller automaton (DMA) uses a [`MullerCondition`] to determine acceptance.
+/// Such a condition consists of a set of sets of colors. It considers an infinite run to
+/// be accepting, if the set of colors that appear infinitely often in the run is an element
+/// of the [`MullerCondition`]. In other words such a Muller condition lists out precisely
+/// the sets of colors that are allowed to appear infinitely often in an accepting run. Note,
+/// that this means if a run is not accepting, then the set of colors it visits infinitely
+/// often is not contained in the [`MullerCondition`]. This allows for easy complementation
+/// of a [`DMA`] by simply taking the complement of the [`MullerCondition`].
+pub type DMA<A = CharAlphabet, C = usize> = Automaton<DTS<A, Void, C>, MullerCondition<C>, true>;
+/// Helper type alias for casting a given transition system `T` into a [`DMA`].
+pub type IntoDMA<T> = Automaton<T, MullerCondition<EdgeColor<T>>, true>;
+
+/// A Muller condition over some [`Color`] `C` is a set of sets of elements of type `C`. It
+/// is satisfied by a set (usually the set of colors that appear infinitely often in a run),
+/// if it contains the set.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct MullerCondition<C: Color>(Set<BTreeSet<C>>);
+
+impl<C: Color> MullerCondition<C> {
+    /// Builds a new instance from an iterator that yields iterators that yield colors
+    /// (or elements of type `C`).
+    ///
+    /// # Example
+    /// ```
+    /// use automata::prelude::*;
+    ///
+    /// let condition = MullerCondition::from_iter_iter([[0], [1]]);
+    ///
+    /// assert!(!condition.satisfied_by_iter([0, 1]));
+    /// assert!(condition.satisfied_by_iter([0]));
+    /// assert!(condition.satisfied_by_iter([1, 1, 1]));
+    /// ```
+    pub fn from_iter_iter<I, J>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = J>,
+        J: IntoIterator<Item = C>,
+    {
+        Self(iter.into_iter().map(|x| x.into_iter().collect()).collect())
+    }
+
+    /// Returns `true` if the given `set` of colors satisfies this condition,
+    /// i.e. if `self` contains `set`.
+    pub fn satisfied_by_set(&self, set: &BTreeSet<C>) -> bool {
+        self.0.contains(set)
+    }
+
+    /// Returns `true` if the set of colors yielded by `iter` satisfy this condition.
+    pub fn satisfied_by_iter<I: IntoIterator<Item = C>>(&self, iter: I) -> bool {
+        self.satisfied_by_set(&iter.into_iter().collect())
+    }
+
+    /// Creates a new instance from a set of sets of colors.
+    pub fn new(sets: Set<BTreeSet<C>>) -> Self {
+        Self(sets)
+    }
+}
+
+impl<Q, C: Color> Semantics<Q, C> for MullerCondition<C> {
+    type Output = bool;
+}
+
+impl<Q, C: Color> OmegaSemantics<Q, C> for MullerCondition<C> {
+    fn evaluate<R>(&self, run: R) -> Self::Output
+    where
+        R: OmegaRun<StateColor = Q, EdgeColor = C>,
+    {
+        let Some(inf) = run
+            .recurring_edge_colors_iter()
+            .map(|x| x.collect::<BTreeSet<_>>())
+        else {
+            return false;
+        };
+        self.0.contains(&inf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn muller_automaton() {
+        let ts = TSBuilder::without_state_colors()
+            .with_transitions([
+                (0, 'a', 0, 0),
+                (0, 'b', 1, 1),
+                (1, 'a', 0, 0),
+                (1, 'b', 1, 1),
+            ])
+            .into_dts();
+        let dra =
+            DMA::from_parts_with_acceptance(ts, 0, MullerCondition::from_iter_iter([[0], [1]]));
+        assert!(dra.accepts(upw!("a")));
+        assert!(dra.accepts(upw!("b")));
+        assert!(!dra.accepts(upw!("ba")));
+    }
+}

--- a/src/automaton/omega/parity.rs
+++ b/src/automaton/omega/parity.rs
@@ -8,22 +8,34 @@ use tracing::{info, trace};
 
 use crate::{math::Partition, prelude::*, transition_system::Shrinkable};
 
+/// A deterministic parity automaton (DPA). It uses a [`DTS`]
+/// as its transition system and a `usize` as its edge color.
+/// The acceptance condition is given by the type `Sem`, which
+/// defaults to [`MinEvenParityCondition`], meaning the automaton accepts
+/// if the least color that appears infinitely often during
+/// a run is even.
+pub type DPA<A = CharAlphabet, Sem = MinEvenParityCondition> =
+    Automaton<DTS<A, Void, usize>, Sem, true>;
+/// Helper type alias for converting a given transition system into a [`DPA`]
+/// with the given semantics.
+pub type IntoDPA<T, Sem = MinEvenParityCondition> = Automaton<T, Sem, true>;
+
 /// Represents a min even parity condition which accepts if and only if the least color
 /// that labels a transition that is taken infinitely often, is even. For the automaton
 /// type that makes use of this semantics, see [`DPA`].
 ///
 /// Other (equivalent) types of parity conditions, that consider the maximal seen color
 /// or demand that the minimal/maximal recurring color are odd, are defined as
-/// [`MaxEvenParitySemantics`], [`MinOddParitySemantics`] and [`MaxOddParitySemantics`],
+/// [`MaxEvenParityCondition`], [`MinOddParityCondition`] and [`MaxOddParityCondition`],
 /// respectively.
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MinEvenParitySemantics;
+pub struct MinEvenParityCondition;
 
-impl<Q> Semantics<Q, usize> for MinEvenParitySemantics {
+impl<Q> Semantics<Q, usize> for MinEvenParityCondition {
     type Output = bool;
 }
 
-impl<Q> OmegaSemantics<Q, usize> for MinEvenParitySemantics {
+impl<Q> OmegaSemantics<Q, usize> for MinEvenParityCondition {
     fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: OmegaRun<StateColor = Q, EdgeColor = usize>,
@@ -36,29 +48,17 @@ impl<Q> OmegaSemantics<Q, usize> for MinEvenParitySemantics {
 }
 
 /// Defines an [`OmegaSemantics`] that outputs `true` if the *maximum* color/priority that
-/// appears infinitely often is *even*. See also [`MinEvenParitySemantics`].
+/// appears infinitely often is *even*. See also [`MinEvenParityCondition`].
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MaxEvenParitySemantics;
+pub struct MaxEvenParityCondition;
 /// Defines an [`OmegaSemantics`] that outputs `true` if the *minimum* color/priority that
-/// appears infinitely often is *odd*. See also [`MinEvenParitySemantics`].
+/// appears infinitely often is *odd*. See also [`MinEvenParityCondition`].
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MinOddParitySemantics;
+pub struct MinOddParityCondition;
 /// Defines an [`OmegaSemantics`] that outputs `true` if the *maximum* color/priority that
-/// appears infinitely often is *odd*. See also [`MinEvenParitySemantics`].
+/// appears infinitely often is *odd*. See also [`MinEvenParityCondition`].
 #[derive(Clone, Debug, Default, Copy, Hash, Eq, PartialEq)]
-pub struct MaxOddParitySemantics;
-
-/// A deterministic parity automaton (DPA). It uses a [`DTS`]
-/// as its transition system and a `usize` as its edge color.
-/// The acceptance condition is given by the type `Sem`, which
-/// defaults to [`MinEvenParitySemantics`], meaning the automaton accepts
-/// if the least color that appears infinitely often during
-/// a run is even.
-pub type DPA<A = CharAlphabet, Sem = MinEvenParitySemantics> =
-    Automaton<DTS<A, Void, usize>, Sem, true>;
-/// Helper trait for converting a given transition system into a [`DPA`]
-/// with the given semantics.
-pub type IntoDPA<T, Sem = MinEvenParitySemantics> = Automaton<T, Sem, true>;
+pub struct MaxOddParityCondition;
 
 impl<D> IntoDPA<D>
 where

--- a/src/automaton/omega/parity.rs
+++ b/src/automaton/omega/parity.rs
@@ -28,7 +28,7 @@ impl<Q> OmegaSemantics<Q, usize> for MinEvenParitySemantics {
     where
         R: OmegaRun<StateColor = Q, EdgeColor = usize>,
     {
-        run.infinity_edge_colors()
+        run.recurring_edge_colors_iter()
             .and_then(|colors| colors.min())
             .map(|x| x % 2 == 0)
             .unwrap_or(false)

--- a/src/automaton/omega/rabin.rs
+++ b/src/automaton/omega/rabin.rs
@@ -3,13 +3,31 @@ use std::collections::BTreeSet;
 use crate::math::Set;
 use crate::prelude::*;
 
-pub type DRA<A = CharAlphabet, C = usize> = Automaton<DTS<A, Void, C>, RabinSemantics<C>, true>;
-pub type IntoDRA<T> = Automaton<T, RabinSemantics<EdgeColor<T>>, true>;
+/// A deterministic Rabin automaton (DRA) uses a [`RabinCondition`] to determine acceptance.
+/// Specifically, such a condition consists of a set of [`RabinPair`]s, which in turn are
+/// made up of a set `fin` and a set `inf`. A Rabin pair is now satisfied by an infinite run
+/// if no color from `fin` is visited infinitely often and at least one color from `inf` is
+/// visited infinitely often. Overall, a Rabin condition is then satisfied if at least one of
+/// its constituent pairs is satisfied.
+pub type DRA<A = CharAlphabet, C = usize> = Automaton<DTS<A, Void, C>, RabinCondition<C>, true>;
+/// Helper type alias for casting a given transition system `T` into a [`DRA`].
+pub type IntoDRA<T> = Automaton<T, RabinCondition<EdgeColor<T>>, true>;
 
+/// Represents a Rabin condition, which is a set of [`RabinPair`]s. Such a condition is satisfied
+/// if at least one of its pairs is satisfied.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct RabinSemantics<C: Color>(Set<RabinPair<C>>);
+pub struct RabinCondition<C: Color>(Set<RabinPair<C>>);
 
-impl<C, I> From<I> for RabinSemantics<C>
+/// A Rabin pair over some [`Color`] `C` consists of a set `fin` and a set `inf` of elements of type `C`.
+/// A pair is satisfied by a set (usually the set of colors that appear infinitely often in a run),
+/// if the set contains no elements of `fin` and at least one element of `inf`.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct RabinPair<C> {
+    pub(crate) fin: BTreeSet<C>,
+    pub(crate) inf: BTreeSet<C>,
+}
+
+impl<C, I> From<I> for RabinCondition<C>
 where
     C: Color,
     I: IntoIterator<Item = RabinPair<C>>,
@@ -19,17 +37,13 @@ where
     }
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
-pub struct RabinPair<C> {
-    pub(crate) fin: BTreeSet<C>,
-    pub(crate) inf: BTreeSet<C>,
-}
-
 impl<C: Color> RabinPair<C> {
+    /// Creates a new pair from the given set of finite and infinite colors.
     pub fn new(fin: BTreeSet<C>, inf: BTreeSet<C>) -> Self {
         Self { fin, inf }
     }
 
+    /// Creates a new pair from iterators giving the set of finite and infinite colors.
     pub fn from_iters<I, J>(fin: I, inf: J) -> Self
     where
         I: IntoIterator<Item = C>,
@@ -41,17 +55,25 @@ impl<C: Color> RabinPair<C> {
         }
     }
 
-    pub fn satisfied_by(&self, colors: &BTreeSet<C>) -> bool {
+    /// Returns true if and only if the pair is satisfied by the given set of colors, i.e.
+    /// if the set contains no color from `fin` and at least one color from `inf`.
+    pub fn satisfied_by_set(&self, colors: &BTreeSet<C>) -> bool {
         self.fin.intersection(colors).next().is_none()
             && self.inf.intersection(colors).next().is_some()
     }
+
+    /// Returns true if and only if the pair is satisfied by the set of colors yielded by `iter`.
+    /// This simply collects and calls [`Self::satisfied_by_set`].
+    pub fn satisfied_by_iter<I: IntoIterator<Item = C>>(&self, colors: I) -> bool {
+        self.satisfied_by_set(&colors.into_iter().collect())
+    }
 }
 
-impl<Q, C: Color> Semantics<Q, C> for RabinSemantics<C> {
+impl<Q, C: Color> Semantics<Q, C> for RabinCondition<C> {
     type Output = bool;
 }
 
-impl<Q, C: Color> OmegaSemantics<Q, C> for RabinSemantics<C> {
+impl<Q, C: Color> OmegaSemantics<Q, C> for RabinCondition<C> {
     fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: OmegaRun<StateColor = Q, EdgeColor = C>,
@@ -61,7 +83,7 @@ impl<Q, C: Color> OmegaSemantics<Q, C> for RabinSemantics<C> {
         };
         let colorset = colors.collect();
 
-        self.0.iter().any(|pair| pair.satisfied_by(&colorset))
+        self.0.iter().any(|pair| pair.satisfied_by_set(&colorset))
     }
 }
 
@@ -73,13 +95,13 @@ mod tests {
     fn rabin_pairs() {
         let pair = RabinPair::from_iters([1], [2]);
         let mut colors = vec![1, 2].into_iter().collect();
-        assert!(!pair.satisfied_by(&colors));
+        assert!(!pair.satisfied_by_set(&colors));
         colors.remove(&1);
-        assert!(pair.satisfied_by(&colors));
+        assert!(pair.satisfied_by_set(&colors));
         colors.remove(&2);
-        assert!(!pair.satisfied_by(&colors));
+        assert!(!pair.satisfied_by_set(&colors));
         colors.insert(1);
-        assert!(!pair.satisfied_by(&colors));
+        assert!(!pair.satisfied_by_set(&colors));
     }
 
     #[test]

--- a/src/automaton/omega/rabin.rs
+++ b/src/automaton/omega/rabin.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeSet;
+
+use crate::math::Set;
+use crate::prelude::*;
+
+pub type DRA<A = CharAlphabet, C = usize> = Automaton<DTS<A, Void, C>, RabinSemantics<C>, true>;
+pub type IntoDRA<T> = Automaton<T, RabinSemantics<EdgeColor<T>>, true>;
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct RabinSemantics<C: Color>(Set<RabinPair<C>>);
+
+impl<C, I> From<I> for RabinSemantics<C>
+where
+    C: Color,
+    I: IntoIterator<Item = RabinPair<C>>,
+{
+    fn from(value: I) -> Self {
+        Self(value.into_iter().collect())
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct RabinPair<C> {
+    pub(crate) fin: BTreeSet<C>,
+    pub(crate) inf: BTreeSet<C>,
+}
+
+impl<C: Color> RabinPair<C> {
+    pub fn new(fin: BTreeSet<C>, inf: BTreeSet<C>) -> Self {
+        Self { fin, inf }
+    }
+
+    pub fn from_iters<I, J>(fin: I, inf: J) -> Self
+    where
+        I: IntoIterator<Item = C>,
+        J: IntoIterator<Item = C>,
+    {
+        Self {
+            fin: fin.into_iter().collect(),
+            inf: inf.into_iter().collect(),
+        }
+    }
+
+    pub fn satisfied_by(&self, colors: &BTreeSet<C>) -> bool {
+        self.fin.intersection(colors).next().is_none()
+            && self.inf.intersection(colors).next().is_some()
+    }
+}
+
+impl<Q, C: Color> Semantics<Q, C> for RabinSemantics<C> {
+    type Output = bool;
+}
+
+impl<Q, C: Color> OmegaSemantics<Q, C> for RabinSemantics<C> {
+    fn evaluate<R>(&self, run: R) -> Self::Output
+    where
+        R: OmegaRun<StateColor = Q, EdgeColor = C>,
+    {
+        let Some(colors) = run.recurring_edge_colors_iter() else {
+            return false;
+        };
+        let colorset = colors.collect();
+
+        self.0.iter().any(|pair| pair.satisfied_by(&colorset))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rabin_pairs() {
+        let pair = RabinPair::from_iters([1], [2]);
+        let mut colors = vec![1, 2].into_iter().collect();
+        assert!(!pair.satisfied_by(&colors));
+        colors.remove(&1);
+        assert!(pair.satisfied_by(&colors));
+        colors.remove(&2);
+        assert!(!pair.satisfied_by(&colors));
+        colors.insert(1);
+        assert!(!pair.satisfied_by(&colors));
+    }
+
+    #[test]
+    fn rabin_automaton() {
+        let ts = TSBuilder::without_state_colors()
+            .with_transitions([
+                (0, 'a', 0, 0),
+                (0, 'b', 1, 1),
+                (1, 'a', 0, 0),
+                (1, 'b', 1, 1),
+            ])
+            .into_dts();
+        let dra = DRA::from_parts_with_acceptance(ts, 0, [RabinPair::from_iters([], [1])].into());
+        assert!(dra.accepts(upw!("ba")));
+        assert!(!dra.accepts(upw!("a")));
+        assert!(dra.accepts(upw!("ab")));
+    }
+}

--- a/src/automaton/reachability.rs
+++ b/src/automaton/reachability.rs
@@ -8,19 +8,19 @@ use super::StatesWithColor;
 /// [`DFA`]. This leads to a [`FiniteWord`] being accepted if the state that it reaches
 /// is colored with `true`, and the word being rejected otherwise.
 #[derive(Clone, Copy, Default, Hash, Eq, PartialEq)]
-pub struct DFASemantics;
+pub struct ReachabilityCondition;
 
-impl std::fmt::Debug for DFASemantics {
+impl std::fmt::Debug for ReachabilityCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "DFA (reach true)")
     }
 }
 
-impl<C> Semantics<bool, C> for DFASemantics {
+impl<C> Semantics<bool, C> for ReachabilityCondition {
     type Output = bool;
 }
 
-impl<C> FiniteSemantics<bool, C> for DFASemantics {
+impl<C> FiniteSemantics<bool, C> for ReachabilityCondition {
     fn evaluate<R>(&self, run: R) -> Self::Output
     where
         R: FiniteRun<StateColor = bool, EdgeColor = C>,
@@ -32,10 +32,10 @@ impl<C> FiniteSemantics<bool, C> for DFASemantics {
 }
 
 /// A deterministic finite automaton (DFA) is a deterministic automaton with a simple acceptance condition. It accepts a finite word if it reaches an accepting state.
-pub type DFA<A = CharAlphabet> = Automaton<DTS<A, bool, Void>, DFASemantics, false>;
+pub type DFA<A = CharAlphabet> = Automaton<DTS<A, bool, Void>, ReachabilityCondition, false>;
 
 /// Helper trait for creating a [`DFA`] from a given transition system.
-pub type IntoDFA<T> = Automaton<T, DFASemantics, false>;
+pub type IntoDFA<T> = Automaton<T, ReachabilityCondition, false>;
 
 impl<D> IntoDFA<D>
 where

--- a/src/automaton/semantics.rs
+++ b/src/automaton/semantics.rs
@@ -20,7 +20,7 @@ use crate::prelude::*;
 /// Examples of this semantic are for example the [`MooreSemantics`], which
 /// for a finite word `w` simply produce the color of the state that is
 /// reached when running `w` in the transition system from the initial state.
-/// This is similar to the [`DFASemantics`], which additionaly demand that
+/// This is similar to the [`ReachabilityCondition`], which additionaly demand that
 /// the state colors are `bool`.
 /// Further, there is also the [`MealySemantics`], which outputs the last
 /// transition that is taken when reading `w`.
@@ -30,10 +30,10 @@ use crate::prelude::*;
 /// `Output` type. This is now computed in the [`OmegaSemantics::evaluate`] method on
 /// the [`OmegaSemantics`] trait. It does this based on an [`OmegaRun`].
 ///
-/// Examples include the [`DBASemantics`], which may be applied to `bool`
+/// Examples include the [`BuchiCondition`], which may be applied to `bool`
 /// edge-colored transition systems. It outputs `true` if any edge labeled
 /// with `true` is visited infinitely often and `false` otherwise.
-/// This can actually be viewed as an instantiation of the [`MinEvenParitySemantics`]
+/// This can actually be viewed as an instantiation of the [`MinEvenParityCondition`]
 /// semantics that a [`DPA`] uses, which outputs the least priority/color
 /// among those that are labels of edges taken infinitely often.
 pub trait Semantics<Q, C> {

--- a/src/automaton/with_initial.rs
+++ b/src/automaton/with_initial.rs
@@ -4,16 +4,16 @@ use std::fmt::Debug;
 /// Auxiliary type that is used as marker for an [`Automaton`] where we are not
 /// interested in the semantics.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Default)]
-pub struct NoSemantics;
+pub struct WithoutCondition;
 
 /// An [`Automaton`] which has no semantics. Essentially, this just fixes one
 /// state as initial.
-pub type WithInitial<Ts> = Automaton<Ts, NoSemantics>;
+pub type WithInitial<Ts> = Automaton<Ts, WithoutCondition>;
 
 impl<Ts: TransitionSystem> WithInitial<Ts> {
     /// Decompose `self` into the transition system and the initial state. This operation
     /// naturally takes ownership of `self` and disregards the semantics (which should not
-    /// matter as it should be [`NoSemantics`] anyways).
+    /// matter as it should be [`WithoutCondition`] anyways).
     pub fn decompose(self) -> (Ts, Ts::StateIndex) {
         (self.ts, self.initial)
     }

--- a/src/congruence.rs
+++ b/src/congruence.rs
@@ -124,6 +124,14 @@ pub struct RightCongruence<A: Alphabet = CharAlphabet, Q = Void, C = Void> {
 }
 
 impl<A: Alphabet, Q: Clone, C: Clone> RightCongruence<A, Q, C> {
+    /// Creates a new [`RightCongruence`] for the given [`Alphabet`]. Since there always has be an initial state,
+    /// the method also expects a color for the initial state which it inserts.
+    pub fn new_with_initial_color(alphabet: A, initial_color: Q) -> Self {
+        let mut ts = DTS::for_alphabet(alphabet);
+        let initial = ts.add_state(initial_color);
+        Self::from_ts(ts.with_initial(initial))
+    }
+
     /// Returns a reference to the underlying transition system.
     pub fn ts(&self) -> &DTS<A, Q, C> {
         &self.ts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,11 @@ pub mod prelude {
         alphabet,
         alphabet::{CharAlphabet, Expression, Symbol},
         automaton::{
-            Automaton, DBASemantics, DFASemantics, FiniteSemantics, IntoDBA, IntoDFA, IntoDPA,
-            IntoMealyMachine, IntoMooreMachine, MealyMachine, MealySemantics,
-            MinEvenParitySemantics, MooreMachine, MooreSemantics, OmegaAcceptanceCondition,
-            OmegaAutomaton, OmegaSemantics, Semantics, WithInitial, DBA, DFA, DPA,
+            Automaton, BuchiCondition, FiniteSemantics, IntoDBA, IntoDFA, IntoDMA, IntoDPA,
+            IntoDRA, IntoMealyMachine, IntoMooreMachine, MealyMachine, MealySemantics,
+            MinEvenParityCondition, MooreMachine, MooreSemantics, MullerCondition,
+            OmegaAcceptanceCondition, OmegaAutomaton, OmegaSemantics, ReachabilityCondition,
+            Semantics, WithInitial, DBA, DFA, DMA, DPA,
         },
         congruence::{Congruence, RightCongruence},
         math,
@@ -57,7 +58,7 @@ pub mod automaton;
 
 /// Defines congruence relations and congruence classes.
 pub mod congruence;
-pub use congruence::{Class, RightCongruence};
+pub use congruence::{Class, Congruence, RightCongruence};
 
 /// Module that contains definitions for dealing with words.
 #[macro_use]

--- a/src/minimization.rs
+++ b/src/minimization.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 
 impl<D> IntoMooreMachine<D>
 where
-    D: Congruence,
+    D: Deterministic,
     StateColor<D>: Color,
 {
     /// Returns the unique minimal moore machine that is bisimilar to `self`. This means
@@ -18,7 +18,7 @@ where
 
 impl<D> IntoMealyMachine<D>
 where
-    D: Congruence,
+    D: Deterministic,
     EdgeColor<D>: Color,
 {
     /// Minimizes `self` using Hopcroft's partition refinement algorithm.
@@ -29,7 +29,7 @@ where
 
 impl<D> IntoDFA<D>
 where
-    D: Congruence<StateColor = bool>,
+    D: Deterministic<StateColor = bool>,
 {
     /// Minimizes `self` using Hopcroft's partition refinement algorithm.
     pub fn minimize(self) -> DFA<D::Alphabet> {

--- a/src/transition_system/run.rs
+++ b/src/transition_system/run.rs
@@ -56,11 +56,11 @@ pub trait OmegaRun {
     /// The type of the state indices.
     type StateIndex: IndexType;
     /// Returns an iterator over the state colors.
-    fn infinity_state_colors(self) -> Option<impl Iterator<Item = Self::StateColor>>;
+    fn recurring_state_colors_iter(self) -> Option<impl Iterator<Item = Self::StateColor>>;
     /// Returns an iterator over the edge colors.
-    fn infinity_edge_colors(self) -> Option<impl Iterator<Item = Self::EdgeColor>>;
+    fn recurring_edge_colors_iter(self) -> Option<impl Iterator<Item = Self::EdgeColor>>;
     /// Returns an iterator over the state indices.
-    fn infinity_indices(self) -> Option<impl Iterator<Item = Self::StateIndex>>;
+    fn recurring_state_indices_iter(self) -> Option<impl Iterator<Item = Self::StateIndex>>;
 }
 
 impl<A: Alphabet, Q: Clone, C: Clone, Idx: IndexType> OmegaRun for OmegaRunResult<A, Idx, Q, C> {
@@ -70,15 +70,15 @@ impl<A: Alphabet, Q: Clone, C: Clone, Idx: IndexType> OmegaRun for OmegaRunResul
 
     type StateIndex = Idx;
 
-    fn infinity_state_colors(self) -> Option<impl Iterator<Item = Self::StateColor>> {
+    fn recurring_state_colors_iter(self) -> Option<impl Iterator<Item = Self::StateColor>> {
         self.ok().map(|path| path.into_recurrent_state_colors())
     }
 
-    fn infinity_edge_colors(self) -> Option<impl Iterator<Item = Self::EdgeColor>> {
+    fn recurring_edge_colors_iter(self) -> Option<impl Iterator<Item = Self::EdgeColor>> {
         self.ok().map(|path| path.into_recurrent_edge_colors())
     }
 
-    fn infinity_indices(self) -> Option<impl Iterator<Item = Self::StateIndex>> {
+    fn recurring_state_indices_iter(self) -> Option<impl Iterator<Item = Self::StateIndex>> {
         self.ok().map(|path| path.into_recurrent_state_indices())
     }
 }


### PR DESCRIPTION
This PR implements Rabin and Muller automata in the same style as the other automaton types. Additionally, it renames the semantics types like `DFASemantics`, `DBASemantics`, ... to `ReachabilityCondition`, `BuchiCondition`, ... 
