### PR TITLE
Alternative Generation of Random Transition Systems

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -4,13 +4,13 @@ use std::{
 };
 
 /// Type alias for sets, we use this to hide which type of `HashSet` we are actually using.
-pub type Set<S> = fxhash::FxHashSet<S>;
+pub type Set<S> = std::collections::HashSet<S>;
 /// Type alias for sets containing elements that can be ordered, we use this to hide the type
 /// `BTreeSet` we are actually using.
 pub type OrderedSet<S> = BTreeSet<S>;
 
 /// Type alias for maps, we use this to hide which type of `HashMap` we are actually using.
-pub type Map<K, V> = fxhash::FxHashMap<K, V>;
+pub type Map<K, V> = std::collections::HashMap<K, V>;
 /// Type alias for maps containing elements that can be ordered, we use this to hide the type
 /// `BTreeMap` we are actually using.
 pub type OrderedMap<K, V> = BTreeMap<K, V>;

--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -86,12 +86,8 @@ pub fn generate_random_ts_sized(symbols: usize, size: usize) -> (DTS, usize) {
 pub fn generate_random_dba(symbols: usize, size: usize) -> DBA {
     // draw random transition system
     let (mut dts, initial) = generate_random_ts_sized(symbols, size);
-    // remove unreachable states (`remove_state()` is not yet implemented)
-    // for q in dts.state_indices() {
-    //     if !dts.is_reachable_from(initial, q) {
-    //         dts.remove_state(q);
-    //     }
-    // }
+    // remove unreachable states
+    dts.trim_from(initial);
     // draw acceptance condition
     dts.map_edge_colors(|_| fastrand::bool())
         .with_initial(initial)
@@ -104,12 +100,8 @@ pub fn generate_random_dba(symbols: usize, size: usize) -> DBA {
 pub fn generate_random_dpa(symbols: usize, size: usize, priorities: usize) -> DPA {
     // draw random transition system
     let (mut dts, initial) = generate_random_ts_sized(symbols, size);
-    // remove unreachable states (`remove_state()` is not yet implemented)
-    // for q in dts.state_indices() {
-    //     if !dts.is_reachable_from(initial, q) {
-    //         dts.remove_state(q);
-    //     }
-    // }
+    // remove unreachable states
+    dts.trim_from(initial);
     // draw acceptance condition
     dts.map_edge_colors(|_| fastrand::usize(..priorities))
         .with_initial(initial)

--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -1,8 +1,11 @@
 #![allow(unused)]
 
+use fxhash::FxBuildHasher;
 use tracing::{debug, info};
 
 use crate::prelude::*;
+
+use self::math::Set;
 
 /// Uses sprout-like algorithm to generate a random transition system. `symbols` determines the
 /// number of distinct symbols in the [`CharAlphabet`]. `probability` determines the probability
@@ -57,6 +60,103 @@ pub fn generate_random_dfa(symbols: usize, probability: f64) -> DFA {
     ts.map_state_colors(|_| fastrand::bool())
         .with_initial(initial)
         .collect_dfa()
+}
+
+/// Generate a random deterministic transition system of size `size` by randomly drawing transitions.
+/// `symbols` determines the number of distinct symbols in the [`CharAlphabet`].
+/// The algorithm is as follows:
+/// 1. Start with `size` states and no transitions.
+/// 2. For each state, for each symbol draw a target state and add the corresponding edge
+/// Note that depending on which state is chosen as the initial state, there may be unreachable states.
+pub fn generate_random_ts_sized(
+    symbols: usize,
+    size: usize,
+) -> (LinkedListTransitionSystem, usize) {
+    let alphabet = CharAlphabet::of_size(symbols);
+    let mut dts = LinkedListTransitionSystem::for_alphabet(alphabet.clone());
+    // add states
+    for i in 0..size {
+        dts.add_state(Void);
+    }
+    // add edges
+    for q in dts.state_indices() {
+        for sym in alphabet.universe() {
+            let target = fastrand::usize(..dts.size());
+            dts.add_edge((q, sym, target));
+        }
+    }
+
+    (dts, 0)
+}
+
+/// Works as [`generate_random_ts_sized`], but returns a [`DBA`] instead by randomly coloring the edges.
+/// Removes unreachable states, that means the resulting DBA may be smaller than `size`.
+pub fn generate_random_dba(symbols: usize, size: usize) -> DBA {
+    // draw random transition system
+    let (mut dts, initial) = generate_random_ts_sized(symbols, size);
+    // remove unreachable states (`remove_state()` is not yet implemented)
+    // for q in dts.state_indices() {
+    //     if !dts.is_reachable_from(initial, q) {
+    //         dts.remove_state(q);
+    //     }
+    // }
+    // draw acceptance condition
+    dts.map_edge_colors(|_| fastrand::bool())
+        .with_initial(initial)
+        .collect_dba()
+}
+
+/// Works as [`generate_random_ts_sized`], but returns a [`DPA`] instead by randomly
+/// assigning priorities in the range `0..priorities` to each edge.
+/// Removes unreachable states, that means the resulting DPA may be smaller than `size`.
+pub fn generate_random_dpa(symbols: usize, size: usize, priorities: usize) -> DPA {
+    // draw random transition system
+    let (mut dts, initial) = generate_random_ts_sized(symbols, size);
+    // remove unreachable states (`remove_state()` is not yet implemented)
+    // for q in dts.state_indices() {
+    //     if !dts.is_reachable_from(initial, q) {
+    //         dts.remove_state(q);
+    //     }
+    // }
+    // draw acceptance condition
+    dts.map_edge_colors(|_| fastrand::usize(..priorities))
+        .with_initial(initial)
+        .collect_dpa()
+}
+
+/// Generate a random `String` over the universe of the `alphabet`
+/// The length of the `String` is drawn uniformly from the range `min_len..=max_len`.
+pub fn generate_random_word(alphabet: &CharAlphabet, min_len: usize, max_len: usize) -> String {
+    let charset: Vec<char> = alphabet.universe().collect();
+
+    let length = fastrand::usize(min_len..=max_len);
+    let random_word: String = (0..length)
+        .map(|_| {
+            let idx = fastrand::usize(..charset.len());
+            charset[idx] as char
+        })
+        .collect();
+
+    random_word
+}
+
+/// Generate a set of `number` random Strings over the universe of the `alphabet`
+/// The length for each sampled word is drawn uniformly from the range `min_len..=max_len`.
+pub fn generate_random_words(
+    alphabet: &CharAlphabet,
+    min_len: usize,
+    max_len: usize,
+    number: usize,
+) -> Set<String> {
+    let charset: Vec<char> = alphabet.universe().collect();
+    let mut word_set = Set::with_capacity_and_hasher(number, FxBuildHasher::default());
+
+    while word_set.len() < number {
+        let random_word = generate_random_word(alphabet, min_len, max_len);
+        word_set.insert(random_word);
+    }
+
+    word_set
 }
 
 struct BenchmarkAverages {
@@ -158,14 +258,50 @@ pub(crate) fn print_random_ts_benchmark(
 
 #[cfg(test)]
 mod tests {
-    use crate::transition_system::Dottable;
+    use crate::{
+        random::{generate_random_dba, generate_random_dpa, generate_random_words, CharAlphabet},
+        transition_system::Dottable,
+        word, TransitionSystem,
+    };
 
-    use super::{generate_random_dfa, print_random_ts_benchmark};
+    use super::{generate_random_dfa, generate_random_ts_sized, print_random_ts_benchmark};
 
     #[test_log::test]
     #[ignore]
     fn bench_random_ts() {
         let recips_of_2: Vec<_> = (1..=6).map(|i| 2usize.saturating_pow(i)).collect();
         print_random_ts_benchmark(&[2, 4, 6], &[2, 4, 8, 16, 32, 320], 100);
+    }
+
+    #[test]
+    fn random_ts_sized() {
+        let (dts, initial) = generate_random_ts_sized(2, 4);
+        println!("{:?}", dts);
+        assert_eq!(dts.size(), 4);
+    }
+
+    #[test]
+    fn random_dba_sized() {
+        let dba = generate_random_dba(2, 10);
+        println!("{:?}", dba);
+        assert!(dba.size() <= 10);
+    }
+
+    #[test]
+    fn random_dpa_sized() {
+        let dpa = generate_random_dpa(2, 10, 3);
+        println!("{:?}", dpa);
+        assert!(dpa.size() <= 10);
+    }
+
+    #[test]
+    fn random_words() {
+        let alphabet = CharAlphabet::of_size(2);
+        let word_set = generate_random_words(&alphabet, 1, 10, 20);
+        for w in word_set.iter() {
+            println!("{:?}", w);
+        }
+
+        assert_eq!(word_set.len(), 20);
     }
 }


### PR DESCRIPTION
Add some functions to randomly generate transition systems, automata and words.

The implemented algorithm for generating transition systems takes a size `n` and adds that many states. Afterwards, edges are randomly drawn. Note that there can be unreachable states.

Based on this algorithm there are functions `generate_random_dba` and `generate_random_dpa` for DBA and DPA respectively. The acceptance conditions are drawn uniformly.

Note that as of now, if there are **unreachable states**, they **remain** in the generated automaton because the function `remove_state()` from the `Shrinkable` trait is not yet implemented for `LinkedListTransitionSystem`.

The algorithm for drawing finite words takes min and max lengths, uniformly draws a random length from that range and afterwards generates a word of that length by uniformly drawing symbols from the universe of the alphabet.
Omega words work equivalently by drawing the spoke and the cycle which are finite words.
