### PR TITLE
Fix substract with overflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,10 +20,9 @@ jobs:
 
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Setup Rust toolchain with caching
-        uses: brndnmtthws/rust-action@v1
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal --no-self-update
+      - uses: Swatinem/rust-cache@v2
       - name: Compile
         run: cargo build
 

--- a/automata-core/src/word/skip.rs
+++ b/automata-core/src/word/skip.rs
@@ -135,7 +135,7 @@ impl<'a, S: Symbol, W: OmegaWord<S>> OmegaWord<S> for Skip<'a, S, W> {
                 .skip(self.offset)
                 .chain(self.cycle().symbols())
                 .collect();
-            ReducedOmegaWord::from_raw_parts(representation, self.cycle_length() - self.offset)
+            ReducedOmegaWord::from_raw_parts(representation, self.spoke_length() - self.offset)
         }
     }
 


### PR DESCRIPTION
The preceding if ensures that `self.offset` < `self.spoke_length()`, but we falsely substracted from `self.cycle_length()` which led to a panic.